### PR TITLE
Fix typo: seeher -> seeder

### DIFF
--- a/web/templates/page/index.html.eex
+++ b/web/templates/page/index.html.eex
@@ -14,7 +14,7 @@
           <tr>
             <th>Name</th>
             <th class="size-heaher">Size</th>
-            <th>Seehers</th>
+            <th>Seeders</th>
             <th>Leechers</th>
             <th>Magnet</th>
             <th>Source</th>


### PR DESCRIPTION
Sorry, just noticed this in the README screenshot and thought it worth fixing.

Great work! :)