### PR TITLE
Fixing the downloader helper

### DIFF
--- a/lib/crawler/helper.ex
+++ b/lib/crawler/helper.ex
@@ -31,11 +31,15 @@ defmodule Magnetissimo.Crawler.Helper do
 
   @spec check_content(String.t) :: {:ok, String.t} | {:error, term()}
   def check_content(url) do
-    result = with  {:ok, headers} <- (HTTPoison.head(url, @headers, @options) |> check_response),
+    response = HTTPoison.head(url, @headers, @options)
+               |> check_response
+
+    result = with  {:ok, headers} <- response
                    {{"Content-Type", types}, _rest} <- List.keytake(headers, "Content-Type", 0),
                    :ok <-  verify_mime(types) do
                     {:ok, url}
             else
+              {:moved, location} -> check_content(location)
               {:error, err}      -> {:error, err}
             end
     result

--- a/lib/crawler/helper.ex
+++ b/lib/crawler/helper.ex
@@ -12,6 +12,8 @@ defmodule Magnetissimo.Crawler.Helper do
     else
       :error ->
         {:error, :bad_url}
+        Logger.warn "Bad URL!"
+        nil
 
       {:ok, %HTTPoison.Response{status_code: 502, body: _, headers: _}} ->
         Logger.warn "502 Bad Gateway on #{url}"


### PR DESCRIPTION
This fix adds 2 features:

* The downloader checks the content type of the pages, and 
* The downloader handles redirections. I haven't fully tested yet so 2 solutions live next to each other for the moment.