### PR TITLE
Add support for deploy to heroku button

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: MIX_ENV=prod mix phoenix.server

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Magnetissimo [![StackShare](http://img.shields.io/badge/tech-stack-0690fa.svg?style=flat)](http://stackshare.io/sergiotapia/magnetissimo)
+# Magnetissimo [![StackShare](http://img.shields.io/badge/tech-stack-0690fa.svg?style=flat)](http://stackshare.io/sergiotapia/magnetissimo) [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
 
 Web application that indexes all popular torrent sites, and saves it to the local database.
 

--- a/app.json
+++ b/app.json
@@ -1,0 +1,28 @@
+{
+    "name": "Magnetissimo",
+    "description": "Web application that indexes all popular torrent sites, and saves it to the local database.",
+    "website": "https://www.reddit.com/r/magnetissimo/",
+    "repository": "https://github.com/sergiotapia/magnetissimo",
+    "success_url": "/summary",
+    "scripts": {
+        "postdeploy": "POOL_SIZE=2 mix ecto.migrate"
+    },
+    "addons": [
+        "heroku-postgresql:hobby-dev"
+    ],
+    "buildpacks": [
+      {
+        "url": "https://github.com/HashNuke/heroku-buildpack-elixir"
+      }
+    ],
+    "env": {
+      "POOL_SIZE": {
+        "description": "The number of workers to run.",
+        "value": "18"
+      },
+      "SECRET_KEY_BASE": {
+        "description": "A newly-generated secret key.",
+        "generator": "secret"
+      }
+    }
+}

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -17,7 +17,14 @@ config :magnetissimo, Magnetissimo.Endpoint,
   cache_static_manifest: "priv/static/manifest.json",
   server: true,
   root: ".",
-  version: Mix.Project.config[:version]
+  version: Mix.Project.config[:version],
+  secret_key_base: System.get_env("SECRET_KEY_BASE")
+
+config :magnetissimo, Magnetissimo.Repo,
+    adapter: Ecto.Adapters.Postgres,
+    url: System.get_env("DATABASE_URL"),
+    pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10"),
+    ssl: true
 
 # Do not print debug messages in production
 config :logger, level: :info
@@ -61,4 +68,4 @@ config :logger, level: :info
 
 # Finally import the config/prod.secret.exs
 # which should be versioned separately.
-import_config "prod.secret.exs"
+# import_config "prod.secret.exs"


### PR DESCRIPTION
This enables one-click deployment to Heroku. I'm not sure changing the production config and adding a Procfile is the best solution/won't mess up any existing deployments, so I'm definitely open to revising this somehow. I did test and make sure it works, though.