### PR TITLE
Fix compiler warning and other things

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -29,43 +29,4 @@ config :magnetissimo, Magnetissimo.Repo,
 # Do not print debug messages in production
 config :logger, level: :info
 
-# ## SSL Support
-#
-# To get SSL working, you will need to add the `https` key
-# to the previous section and set your `:url` port to 443:
-#
-#     config :magnetissimo, Magnetissimo.Endpoint,
-#       ...
-#       url: [host: "example.com", port: 443],
-#       https: [port: 443,
-#               keyfile: System.get_env("SOME_APP_SSL_KEY_PATH"),
-#               certfile: System.get_env("SOME_APP_SSL_CERT_PATH")]
-#
-# Where those two env variables return an absolute path to
-# the key and cert in disk or a relative path inside priv,
-# for example "priv/ssl/server.key".
-#
-# We also recommend setting `force_ssl`, ensuring no data is
-# ever sent via http, always redirecting to https:
-#
-#     config :magnetissimo, Magnetissimo.Endpoint,
-#       force_ssl: [hsts: true]
-#
-# Check `Plug.SSL` for all available options in `force_ssl`.
-
-# ## Using releases
-#
-# If you are doing OTP releases, you need to instruct Phoenix
-# to start the server for all endpoints:
-#
-#     config :phoenix, :serve_endpoints, true
-#
-# Alternatively, you can configure exactly which server to
-# start per endpoint:
-#
-#     config :magnetissimo, Magnetissimo.Endpoint, server: true
-#
-
-# Finally import the config/prod.secret.exs
-# which should be versioned separately.
-# import_config "prod.secret.exs"
+import_config "prod.secret.exs"

--- a/lib/crawler/demonoid.ex
+++ b/lib/crawler/demonoid.ex
@@ -43,7 +43,7 @@ defmodule Magnetissimo.Crawler.Demonoid do
     :queue.from_list(urls)
   end
 
-  def torrent_links(html_body) do
+  def torrent_links(html_body) when is_binary(html_body) do
     html_body
     |> Floki.find("td.tone_1_pad a")
     |> Floki.attribute("href")
@@ -51,7 +51,7 @@ defmodule Magnetissimo.Crawler.Demonoid do
     |> Enum.map(fn(url) -> "https://www.demonoid.pw" <> url end)
   end
 
-  def torrent_information(html_body) do
+  def torrent_information(html_body) when is_binary(html_body) do
     name = html_body
       |> Floki.find("td.ctable_header")
       |> Floki.text

--- a/lib/crawler/demonoid.ex
+++ b/lib/crawler/demonoid.ex
@@ -1,6 +1,7 @@
 defmodule Magnetissimo.Crawler.Demonoid do
   use GenServer
   alias Magnetissimo.Crawler.Helper
+  alias Magnetissimo.Torrent.T 
   
   require Logger
 
@@ -51,6 +52,7 @@ defmodule Magnetissimo.Crawler.Demonoid do
     |> Enum.map(fn(url) -> "https://www.demonoid.pw" <> url end)
   end
 
+  @spec torrent_information(String.t) :: T.t
   def torrent_information(html_body) when is_binary(html_body) do
     name = html_body
       |> Floki.find("td.ctable_header")
@@ -88,7 +90,7 @@ defmodule Magnetissimo.Crawler.Demonoid do
     unit = Enum.at(size, 1)
     size = Helper.size_to_bytes(size_value, unit) |> Kernel.to_string
 
-    %{
+    %T{
       name: name,
       magnet: magnet,
       size: size,

--- a/lib/crawler/demonoid.ex
+++ b/lib/crawler/demonoid.ex
@@ -4,7 +4,7 @@ defmodule Magnetissimo.Crawler.Demonoid do
   alias Magnetissimo.Crawler.Helper
 
   def start_link do
-    queue = initial_queue
+    queue = initial_queue()
     GenServer.start_link(__MODULE__, queue)
   end
 
@@ -26,7 +26,7 @@ defmodule Magnetissimo.Crawler.Demonoid do
         queue = process(item, queue)
       _ ->
         IO.puts "Queue is empty - restarting queue."
-        queue = initial_queue
+        queue = initial_queue()
     end
     schedule_work()
     {:noreply, queue}

--- a/lib/crawler/demonoid.ex
+++ b/lib/crawler/demonoid.ex
@@ -1,7 +1,7 @@
 defmodule Magnetissimo.Crawler.Demonoid do
   use GenServer
   alias Magnetissimo.Crawler.Helper
-  alias Magnetissimo.Torrent.T 
+  alias Magnetissimo.Torrent
   
   require Logger
 
@@ -90,7 +90,7 @@ defmodule Magnetissimo.Crawler.Demonoid do
     unit = Enum.at(size, 1)
     size = Helper.size_to_bytes(size_value, unit) |> Kernel.to_string
 
-    %T{
+    %{
       name: name,
       magnet: magnet,
       size: size,

--- a/lib/crawler/demonoid.ex
+++ b/lib/crawler/demonoid.ex
@@ -1,7 +1,8 @@
 defmodule Magnetissimo.Crawler.Demonoid do
   use GenServer
-  alias Magnetissimo.Torrent
   alias Magnetissimo.Crawler.Helper
+  
+  require Logger
 
   def start_link do
     queue = initial_queue()
@@ -20,32 +21,17 @@ defmodule Magnetissimo.Crawler.Demonoid do
   # Callbacks
 
   def handle_info(:work, queue) do
-    case :queue.out(queue) do
-      {{_value, item}, queue_2} ->
-        queue = queue_2
-        queue = process(item, queue)
+    new_queue = case :queue.out(queue) do
+      {{_value, {:page_link, url}}, queue_2} ->
+        Helper.process({:page_link, url}, queue_2, fn x -> torrent_links(x) end)
+      {{_value, {:torrent_link, url}}, queue_2} ->
+        Helper.process({:torrent_link, url}, queue_2, fn x -> torrent_information(x) end)
       _ ->
-        IO.puts "Queue is empty - restarting queue."
-        queue = initial_queue()
+        Logger.debug "[Demonoid] Queue is empty - restarting queue."
+        initial_queue()
     end
     schedule_work()
-    {:noreply, queue}
-  end
-
-  def process({:page_link, url}, queue) do
-    IO.puts "Downloading page: #{url}"
-    torrents = Helper.download(url) |> torrent_links
-    queue = Enum.reduce(torrents, queue, fn torrent, queue ->
-      :queue.in({:torrent_link, torrent}, queue)
-    end)
-    queue
-  end
-
-  def process({:torrent_link, url}, queue) do
-    IO.puts "Downloading torrent: #{url}"
-    torrent_struct = Helper.download(url) |> torrent_information
-    Torrent.save_torrent(torrent_struct)
-    queue
+    {:noreply, new_queue}
   end
 
   # Parser functions
@@ -75,9 +61,10 @@ defmodule Magnetissimo.Crawler.Demonoid do
       |> String.trim
       |> HtmlEntities.decode
 
-    description = html_body
-      |> Floki.find("span.adbriteinline")
-      |> Floki.text
+    # Not used
+    # description = html_body
+    #   |> Floki.find("span.adbriteinline")
+    #   |> Floki.text
 
     magnet = html_body
       |> Floki.find("a")

--- a/lib/crawler/eztv.ex
+++ b/lib/crawler/eztv.ex
@@ -44,7 +44,7 @@ defmodule Magnetissimo.Crawler.EZTV do
     :queue.from_list(urls)
   end
 
-  def torrent_links(html_body) do
+  def torrent_links(html_body) when is_binary(html_body) do
     html_body
     |> Floki.find("a.epinfo")
     |> Floki.attribute("href")
@@ -52,7 +52,7 @@ defmodule Magnetissimo.Crawler.EZTV do
     |> Enum.map(fn(url) -> "https://eztv.ag" <> url end)
   end
 
-  def torrent_information(html_body) do
+  def torrent_information(html_body) when is_binary(html_body) do
     name = html_body
       |> Floki.find("td.section_post_header")
       |> Enum.at(0)

--- a/lib/crawler/eztv.ex
+++ b/lib/crawler/eztv.ex
@@ -1,7 +1,7 @@
 defmodule Magnetissimo.Crawler.EZTV do
   use GenServer
   alias Magnetissimo.Crawler.Helper
-  alias Magnetissimo.Torrent.T 
+  alias Magnetissimo.Torrent 
   
   require Logger
 
@@ -98,7 +98,7 @@ defmodule Magnetissimo.Crawler.EZTV do
 
     size = Helper.size_to_bytes(size_value, unit) |> Kernel.to_string
 
-    %T{
+    %{
       name: name,
       magnet: magnet,
       size: size,

--- a/lib/crawler/eztv.ex
+++ b/lib/crawler/eztv.ex
@@ -1,7 +1,8 @@
 defmodule Magnetissimo.Crawler.EZTV do
   use GenServer
-  alias Magnetissimo.Torrent
   alias Magnetissimo.Crawler.Helper
+  
+  require Logger
 
   def start_link do
     queue = initial_queue()
@@ -20,33 +21,19 @@ defmodule Magnetissimo.Crawler.EZTV do
   # Callbacks
 
   def handle_info(:work, queue) do
-    case :queue.out(queue) do
-      {{_value, item}, queue_2} ->
-        queue = queue_2
-        queue = process(item, queue)
+    new_queue = case :queue.out(queue) do
+      {{_value, {:page_link, url}}, queue_2} ->
+        Helper.process({:page_link, url}, queue_2, fn x -> torrent_links(x) end)
+      {{_value, {:torrent_link, url}}, queue_2} ->
+        Helper.process({:torrent_link, url}, queue_2, fn x -> torrent_information(x) end)
       _ ->
-        IO.puts "Queue is empty - restarting queue."
-        queue = initial_queue()
+        Logger.debug "[EZTV] Queue is empty - restarting queue."
+        initial_queue()
     end
     schedule_work()
-    {:noreply, queue}
+    {:noreply, new_queue}
   end
 
-  def process({:page_link, url}, queue) do
-    IO.puts "Downloading page: #{url}"
-    torrents = Helper.download(url) |> torrent_links
-    queue = Enum.reduce(torrents, queue, fn torrent, queue ->
-      :queue.in({:torrent_link, torrent}, queue)
-    end)
-    queue
-  end
-
-  def process({:torrent_link, url}, queue) do
-    IO.puts "Downloading torrent: #{url}"
-    torrent_struct = Helper.download(url) |> torrent_information
-    Torrent.save_torrent(torrent_struct)
-    queue
-  end
 
   # Parser functions
 

--- a/lib/crawler/eztv.ex
+++ b/lib/crawler/eztv.ex
@@ -4,7 +4,7 @@ defmodule Magnetissimo.Crawler.EZTV do
   alias Magnetissimo.Crawler.Helper
 
   def start_link do
-    queue = initial_queue
+    queue = initial_queue()
     GenServer.start_link(__MODULE__, queue)
   end
 
@@ -26,7 +26,7 @@ defmodule Magnetissimo.Crawler.EZTV do
         queue = process(item, queue)
       _ ->
         IO.puts "Queue is empty - restarting queue."
-        queue = initial_queue
+        queue = initial_queue()
     end
     schedule_work()
     {:noreply, queue}

--- a/lib/crawler/eztv.ex
+++ b/lib/crawler/eztv.ex
@@ -1,6 +1,7 @@
 defmodule Magnetissimo.Crawler.EZTV do
   use GenServer
   alias Magnetissimo.Crawler.Helper
+  alias Magnetissimo.Torrent.T 
   
   require Logger
 
@@ -52,6 +53,7 @@ defmodule Magnetissimo.Crawler.EZTV do
     |> Enum.map(fn(url) -> "https://eztv.ag" <> url end)
   end
 
+  @spec torrent_information(String.t) :: T.t
   def torrent_information(html_body) when is_binary(html_body) do
     name = html_body
       |> Floki.find("td.section_post_header")
@@ -96,7 +98,7 @@ defmodule Magnetissimo.Crawler.EZTV do
 
     size = Helper.size_to_bytes(size_value, unit) |> Kernel.to_string
 
-    %{
+    %T{
       name: name,
       magnet: magnet,
       size: size,

--- a/lib/crawler/helper.ex
+++ b/lib/crawler/helper.ex
@@ -105,6 +105,11 @@ defmodule Magnetissimo.Crawler.Helper do
     queue
   end
 
+  def size_to_bytes(:error) do
+    Logger.warn "Why would you try to convert `:error`?????"
+    0
+  end
+
   def size_to_bytes(size, unit) when is_binary(size) do
     {size_int, _} = Integer.parse(size)
     size_to_bytes(size_int, unit)

--- a/lib/crawler/helper.ex
+++ b/lib/crawler/helper.ex
@@ -8,7 +8,7 @@ defmodule Magnetissimo.Crawler.Helper do
   @spec download(String.t) :: String.t | nil
   @doc """
   This helper returns the HTML body associated with its argument.
-  It does not directly download the page. Instead, it first checks the MIME type
+ It does not directly download the page. Instead, it first checks the MIME type
   of the page with `check_content/1`. Then according to the result of this function,
   either the HTML body is returned, or `nil`, with an error message printed on the console.
   """

--- a/lib/crawler/leetx.ex
+++ b/lib/crawler/leetx.ex
@@ -4,7 +4,7 @@ defmodule Magnetissimo.Crawler.Leetx do
   alias Magnetissimo.Crawler.Helper
 
   def start_link do
-    queue = initial_queue
+    queue = initial_queue()
     GenServer.start_link(__MODULE__, queue)
   end
 
@@ -26,7 +26,7 @@ defmodule Magnetissimo.Crawler.Leetx do
         queue = process(item, queue)
       _ ->
         IO.puts "Queue is empty - restarting queue."
-        queue = initial_queue
+        queue = initial_queue()
     end
     schedule_work()
     {:noreply, queue}

--- a/lib/crawler/leetx.ex
+++ b/lib/crawler/leetx.ex
@@ -1,7 +1,8 @@
 defmodule Magnetissimo.Crawler.Leetx do
   use GenServer
-  alias Magnetissimo.Torrent
   alias Magnetissimo.Crawler.Helper
+  
+  require Logger
 
   def start_link do
     queue = initial_queue()
@@ -20,32 +21,17 @@ defmodule Magnetissimo.Crawler.Leetx do
   # Callbacks
 
   def handle_info(:work, queue) do
-    case :queue.out(queue) do
-      {{_value, item}, queue_2} ->
-        queue = queue_2
-        queue = process(item, queue)
+    new_queue = case :queue.out(queue) do
+      {{_value, {:page_link, url}}, queue_2} ->
+        Helper.process({:page_link, url}, queue_2, fn x -> torrent_links(x) end)
+      {{_value, {:torrent_link, url}}, queue_2} ->
+        Helper.process({:torrent_link, url}, queue_2, fn x -> torrent_information(x) end)
       _ ->
-        IO.puts "Queue is empty - restarting queue."
-        queue = initial_queue()
+        Logger.debug "[Leetx] Queue is empty - restarting queue."
+        initial_queue()
     end
     schedule_work()
-    {:noreply, queue}
-  end
-
-  def process({:page_link, url}, queue) do
-    IO.puts "Downloading page: #{url}"
-    torrents = Helper.download(url) |> torrent_links
-    queue = Enum.reduce(torrents, queue, fn torrent, queue ->
-      :queue.in({:torrent_link, torrent}, queue)
-    end)
-    queue
-  end
-
-  def process({:torrent_link, url}, queue) do
-    IO.puts "Downloading torrent: #{url}"
-    torrent_struct = Helper.download(url) |> torrent_information
-    Torrent.save_torrent(torrent_struct)
-    queue
+    {:noreply, new_queue}
   end
 
   # Parser functions

--- a/lib/crawler/leetx.ex
+++ b/lib/crawler/leetx.ex
@@ -2,6 +2,7 @@ defmodule Magnetissimo.Crawler.Leetx do
   use GenServer
   alias Magnetissimo.Crawler.Helper
   require Logger
+  alias Magnetissimo.Torrent.T 
 
   def start_link do
     queue = initial_queue()
@@ -61,11 +62,12 @@ defmodule Magnetissimo.Crawler.Leetx do
     |> Enum.map(fn(url) -> "https://1337x.to" <> url end)
   end
 
+  @spec torrent_information(String.t) :: T.t
   def torrent_information(html_body) when is_binary(html_body) do
     name = html_body
       |> Floki.find("title")
       |> Floki.text
-      |> String.replace("Download Torrent ", "")
+      |> String.replace("Download Torrent.T ", "")
       |> String.replace("| 1337x", "")
       |> String.replace("Download ", "")
       |> String.trim
@@ -99,7 +101,7 @@ defmodule Magnetissimo.Crawler.Leetx do
       |> Floki.text
       |> Integer.parse
 
-    %{
+    %T{
       name: name,
       magnet: magnet,
       size: size,

--- a/lib/crawler/leetx.ex
+++ b/lib/crawler/leetx.ex
@@ -1,7 +1,6 @@
 defmodule Magnetissimo.Crawler.Leetx do
   use GenServer
   alias Magnetissimo.Crawler.Helper
-  
   require Logger
 
   def start_link do
@@ -54,7 +53,7 @@ defmodule Magnetissimo.Crawler.Leetx do
     :queue.from_list(urls)
   end
 
-  def torrent_links(html_body) do
+  def torrent_links(html_body) when is_binary(html_body) do
     html_body
     |> Floki.find("a")
     |> Floki.attribute("href")
@@ -62,7 +61,7 @@ defmodule Magnetissimo.Crawler.Leetx do
     |> Enum.map(fn(url) -> "https://1337x.to" <> url end)
   end
 
-  def torrent_information(html_body) do
+  def torrent_information(html_body) when is_binary(html_body) do
     name = html_body
       |> Floki.find("title")
       |> Floki.text

--- a/lib/crawler/leetx.ex
+++ b/lib/crawler/leetx.ex
@@ -1,8 +1,8 @@
 defmodule Magnetissimo.Crawler.Leetx do
   use GenServer
   alias Magnetissimo.Crawler.Helper
+  alias Magnetissimo.Torrent 
   require Logger
-  alias Magnetissimo.Torrent.T 
 
   def start_link do
     queue = initial_queue()
@@ -101,7 +101,7 @@ defmodule Magnetissimo.Crawler.Leetx do
       |> Floki.text
       |> Integer.parse
 
-    %T{
+    %{
       name: name,
       magnet: magnet,
       size: size,

--- a/lib/crawler/limetorrents.ex
+++ b/lib/crawler/limetorrents.ex
@@ -4,7 +4,7 @@ defmodule Magnetissimo.Crawler.LimeTorrents do
   alias Magnetissimo.Crawler.Helper
 
   def start_link do
-    queue = initial_queue
+    queue = initial_queue()
     GenServer.start_link(__MODULE__, queue)
   end
 
@@ -26,7 +26,7 @@ defmodule Magnetissimo.Crawler.LimeTorrents do
         queue = process(item, queue)
       _ ->
         IO.puts "Queue is empty - restarting queue."
-        queue = initial_queue
+        queue = initial_queue()
     end
     schedule_work()
     {:noreply, queue}

--- a/lib/crawler/limetorrents.ex
+++ b/lib/crawler/limetorrents.ex
@@ -1,7 +1,8 @@
 defmodule Magnetissimo.Crawler.LimeTorrents do
   use GenServer
-  alias Magnetissimo.Torrent
   alias Magnetissimo.Crawler.Helper
+  
+  require Logger
 
   def start_link do
     queue = initial_queue()
@@ -20,36 +21,38 @@ defmodule Magnetissimo.Crawler.LimeTorrents do
   # Callbacks
 
   def handle_info(:work, queue) do
-    case :queue.out(queue) do
-      {{_value, item}, queue_2} ->
-        queue = queue_2
-        queue = process(item, queue)
+    new_queue = case :queue.out(queue) do
+      {{_value, {:page_link, url}}, queue_2} ->
+        Helper.process({:page_link, url}, queue_2, fn x -> torrent_links(x) end)
+      {{_value, {:torrent_link, url}}, queue_2} ->
+        Helper.process({:torrent_link, url}, queue_2, fn x -> torrent_information(x) end)
       _ ->
-        IO.puts "Queue is empty - restarting queue."
-        queue = initial_queue()
+        Logger.debug "[LimeTorrents] Queue is empty - restarting queue."
+        initial_queue()
     end
     schedule_work()
-    {:noreply, queue}
+    {:noreply, new_queue}
   end
 
-  def process({:page_link, url}, queue) do
-    IO.puts "Downloading page: #{url}"
-    torrents = Helper.download(url) |> torrent_links
-    queue = Enum.reduce(torrents, queue, fn torrent, queue ->
-      :queue.in({:torrent_link, torrent}, queue)
-    end)
-    queue
-  end
+  # Let just keep that here for the moment.
+  # def process({:page_link, url}, queue) do
+  #   IO.puts "Downloading page: #{url}"
+  #   torrents = Helper.download(url) |> torrent_links
+  #   queue = Enum.reduce(torrents, queue, fn torrent, queue ->
+  #     :queue.in({:torrent_link, torrent}, queue)
+  #   end)
+  #   queue
+  # end
 
-  def process({:torrent_link, url}, queue) do
-    IO.puts "Downloading torrent: #{url}"
-    html_body = Helper.download(url)
-    if String.length(html_body) > 300 do
-      torrent_struct = torrent_information(html_body)
-      Torrent.save_torrent(torrent_struct)
-    end
-    queue
-  end
+  # def process({:torrent_link, url}, queue) do
+  #   IO.puts "Downloading torrent: #{url}"
+  #   html_body = Helper.download(url)
+  #   if String.length(html_body) > 300 do
+  #     torrent_struct = torrent_information(html_body)
+  #     Torrent.save_torrent(torrent_struct)
+  #   end
+  #   queue
+  # end
 
   # Parser functions
 

--- a/lib/crawler/limetorrents.ex
+++ b/lib/crawler/limetorrents.ex
@@ -1,7 +1,7 @@
-defmodule Magnetissimo.Crawler.LimeTorrent.Ts do
+defmodule Magnetissimo.Crawler.LimeTorrents do
   use GenServer
   alias Magnetissimo.Crawler.Helper
-  alias Magnetissimo.Torrent.T 
+  alias Magnetissimo.Torrent 
   require Logger
 
   def start_link do
@@ -85,7 +85,7 @@ defmodule Magnetissimo.Crawler.LimeTorrent.Ts do
     unit = String.split(size_html) |> Enum.at(1)
     size = Helper.size_to_bytes(size_value, unit) |> Kernel.to_string
 
-    %T{
+    %{
       name: name,
       magnet: magnet,
       size: size,

--- a/lib/crawler/limetorrents.ex
+++ b/lib/crawler/limetorrents.ex
@@ -1,7 +1,7 @@
-defmodule Magnetissimo.Crawler.LimeTorrents do
+defmodule Magnetissimo.Crawler.LimeTorrent.Ts do
   use GenServer
   alias Magnetissimo.Crawler.Helper
-  
+  alias Magnetissimo.Torrent.T 
   require Logger
 
   def start_link do
@@ -27,7 +27,7 @@ defmodule Magnetissimo.Crawler.LimeTorrents do
       {{_value, {:torrent_link, url}}, queue_2} ->
         Helper.process({:torrent_link, url}, queue_2, fn x -> torrent_information(x) end)
       _ ->
-        Logger.debug "[LimeTorrents] Queue is empty - restarting queue."
+        Logger.debug "[LimeTorrent.Ts] Queue is empty - restarting queue."
         initial_queue()
     end
     schedule_work()
@@ -64,6 +64,7 @@ defmodule Magnetissimo.Crawler.LimeTorrents do
     |> Enum.map(fn(url) -> "https://www.limetorrents.cc" <> url end)
   end
 
+  @spec torrent_information(String.t) :: T.t
   def torrent_information(html_body) when is_binary(html_body) do
     name = html_body
       |> Floki.find("h1")
@@ -84,7 +85,7 @@ defmodule Magnetissimo.Crawler.LimeTorrents do
     unit = String.split(size_html) |> Enum.at(1)
     size = Helper.size_to_bytes(size_value, unit) |> Kernel.to_string
 
-    %{
+    %T{
       name: name,
       magnet: magnet,
       size: size,

--- a/lib/crawler/limetorrents.ex
+++ b/lib/crawler/limetorrents.ex
@@ -34,33 +34,6 @@ defmodule Magnetissimo.Crawler.LimeTorrents do
     {:noreply, new_queue}
   end
 
-  def process({:page_link, url}, queue) do
-    IO.puts "Downloading page: #{url}"
-    torrents = Helper.download(url) |> torrent_links
-    cond do
-      is_nil(torrents) -> nil
-      true -> queue = Enum.reduce(torrents, queue, fn torrent, queue ->
-                :queue.in({:torrent_link, torrent}, queue)
-              end)
-    end
-    queue
-  end
-
-  def process({:torrent_link, url}, queue) do
-    IO.puts "Downloading torrent: #{url}"
-    html_body = Helper.download(url)
-    cond do
-      is_nil(html_body)    -> nil
-
-      is_binary(html_body) ->
-        torrent_struct = torrent_information(html_body)
-        Torrent.save_torrent(torrent_struct)
-
-      true                 -> nil
-    end
-    queue
-  end
-
   # Parser functions
 
   def initial_queue do

--- a/lib/crawler/monova.ex
+++ b/lib/crawler/monova.ex
@@ -1,7 +1,7 @@
 defmodule Magnetissimo.Crawler.Monova do
   use GenServer
   alias Magnetissimo.Crawler.Helper
-  alias Magnetissimo.Torrent.T
+  alias Magnetissimo.Torrent
   require Logger
 
   def start_link do
@@ -74,7 +74,7 @@ defmodule Magnetissimo.Crawler.Monova do
     size = Helper.size_to_bytes(size_value, unit) |> Kernel.to_string
 
     ## Leechers and Seeders informations are not provided by Monova.
-    %T{
+    %{
       name: name,
       magnet: magnet,
       size: size,

--- a/lib/crawler/monova.ex
+++ b/lib/crawler/monova.ex
@@ -45,7 +45,8 @@ defmodule Magnetissimo.Crawler.Monova do
     :queue.from_list(urls)
   end
 
-  def torrent_links(cat_body) do
+  @spec torrent_links(String.t) :: [String.t]
+  def torrent_links(cat_body) when is_binary(cat_body) do
     Logger.debug "[Monova] Extracting Torrents"
     cat_body
     |> Floki.find("a")
@@ -54,7 +55,7 @@ defmodule Magnetissimo.Crawler.Monova do
     |> Enum.map(fn(url) -> "https:" <> url end)
   end
 
-  def torrent_information(torrent_body) do
+  def torrent_information(torrent_body) when is_binary(torrent_body) do
     name = torrent_body
       |> Floki.find("title")
       |> Floki.text

--- a/lib/crawler/monova.ex
+++ b/lib/crawler/monova.ex
@@ -1,7 +1,7 @@
 defmodule Magnetissimo.Crawler.Monova do
   use GenServer
   alias Magnetissimo.Crawler.Helper
-  
+  alias Magnetissimo.Torrent.T
   require Logger
 
   def start_link do
@@ -47,7 +47,7 @@ defmodule Magnetissimo.Crawler.Monova do
 
   @spec torrent_links(String.t) :: [String.t]
   def torrent_links(cat_body) when is_binary(cat_body) do
-    Logger.debug "[Monova] Extracting Torrents"
+    Logger.debug "[Monova] Extracting Torrent.Ts"
     cat_body
     |> Floki.find("a")
     |> Floki.attribute("href")
@@ -55,11 +55,12 @@ defmodule Magnetissimo.Crawler.Monova do
     |> Enum.map(fn(url) -> "https:" <> url end)
   end
 
+  @spec torrent_information(String.t) :: T.t
   def torrent_information(torrent_body) when is_binary(torrent_body) do
     name = torrent_body
       |> Floki.find("title")
       |> Floki.text
-      |> String.replace(" - Torrent", "")
+      |> String.replace(" - Torrent.T", "")
       |> String.trim
 
     magnet = torrent_body
@@ -73,7 +74,7 @@ defmodule Magnetissimo.Crawler.Monova do
     size = Helper.size_to_bytes(size_value, unit) |> Kernel.to_string
 
     ## Leechers and Seeders informations are not provided by Monova.
-    %{
+    %T{
       name: name,
       magnet: magnet,
       size: size,

--- a/lib/crawler/thepiratebay.ex
+++ b/lib/crawler/thepiratebay.ex
@@ -1,7 +1,9 @@
 defmodule Magnetissimo.Crawler.ThePirateBay do
   use GenServer
   alias Magnetissimo.Crawler.Helper
+  alias Magnetissimo.Torrent.T
   require Logger
+
 
   def start_link do
     queue = initial_queue()
@@ -14,7 +16,7 @@ defmodule Magnetissimo.Crawler.ThePirateBay do
   end
 
   defp schedule_work do
-    Process.send_after(self(), :work, 5000) # 5 seconds
+    Process.send_after(self(), :work, 1 * 1 * 100) # 5 seconds
   end
 
   # Callbacks
@@ -49,6 +51,7 @@ defmodule Magnetissimo.Crawler.ThePirateBay do
     |> Enum.map(fn(url) -> "https://thepiratebay.org" <> url end)
   end
 
+  @spec torrent_information(String.t) :: T.t
   def torrent_information(html_body) when is_binary(html_body) do
     name = html_body
       |> Floki.find("#title")
@@ -82,7 +85,7 @@ defmodule Magnetissimo.Crawler.ThePirateBay do
       |> Floki.text
       |> Integer.parse
 
-    %{
+    %T{
       name: name,
       magnet: magnet,
       size: size,

--- a/lib/crawler/thepiratebay.ex
+++ b/lib/crawler/thepiratebay.ex
@@ -4,7 +4,7 @@ defmodule Magnetissimo.Crawler.ThePirateBay do
   alias Magnetissimo.Crawler.Helper
 
   def start_link do
-    queue = initial_queue
+    queue = initial_queue()
     GenServer.start_link(__MODULE__, queue)
   end
 
@@ -26,7 +26,7 @@ defmodule Magnetissimo.Crawler.ThePirateBay do
         queue = process(item, queue)
       _ ->
         IO.puts "Queue is empty - restarting queue."
-        queue = initial_queue
+        queue = initial_queue()
     end
     schedule_work()
     {:noreply, queue}

--- a/lib/crawler/thepiratebay.ex
+++ b/lib/crawler/thepiratebay.ex
@@ -1,7 +1,6 @@
 defmodule Magnetissimo.Crawler.ThePirateBay do
   use GenServer
   alias Magnetissimo.Crawler.Helper
-  
   require Logger
 
   def start_link do
@@ -43,14 +42,14 @@ defmodule Magnetissimo.Crawler.ThePirateBay do
     :queue.from_list(urls)
   end
 
-  def torrent_links(html_body) do
+  def torrent_links(html_body) when is_binary(html_body) do
     html_body
     |> Floki.find(".detName a")
     |> Floki.attribute("href")
     |> Enum.map(fn(url) -> "https://thepiratebay.org" <> url end)
   end
 
-  def torrent_information(html_body) do
+  def torrent_information(html_body) when is_binary(html_body) do
     name = html_body
       |> Floki.find("#title")
       |> Floki.text

--- a/lib/crawler/thepiratebay.ex
+++ b/lib/crawler/thepiratebay.ex
@@ -1,7 +1,8 @@
 defmodule Magnetissimo.Crawler.ThePirateBay do
   use GenServer
-  alias Magnetissimo.Torrent
   alias Magnetissimo.Crawler.Helper
+  
+  require Logger
 
   def start_link do
     queue = initial_queue()
@@ -20,38 +21,17 @@ defmodule Magnetissimo.Crawler.ThePirateBay do
   # Callbacks
 
   def handle_info(:work, queue) do
-    case :queue.out(queue) do
-      {{_value, item}, queue_2} ->
-        queue = queue_2
-        queue = process(item, queue)
+    new_queue = case :queue.out(queue) do
+      {{_value, {:page_link, url}}, queue_2} ->
+        Helper.process({:page_link, url}, queue_2, fn x -> torrent_links(x) end)
+      {{_value, {:torrent_link, url}}, queue_2} ->
+        Helper.process({:torrent_link, url}, queue_2, fn x -> torrent_information(x) end)
       _ ->
-        IO.puts "Queue is empty - restarting queue."
-        queue = initial_queue()
+        Logger.debug "[ThePirateBay] Queue is empty - restarting queue."
+        initial_queue()
     end
     schedule_work()
-    {:noreply, queue}
-  end
-
-  def process({:page_link, url}, queue) do
-    IO.puts "Downloading page: #{url}"
-    html_body = Helper.download(url)
-    if html_body != nil do
-      torrents = torrent_links(html_body)
-      queue = Enum.reduce(torrents, queue, fn torrent, queue ->
-        :queue.in({:torrent_link, torrent}, queue)
-      end)
-    end
-    queue
-  end
-
-  def process({:torrent_link, url}, queue) do
-    IO.puts "Downloading torrent: #{url}"
-    html_body = Helper.download(url)
-    if html_body != nil do
-      torrent_struct = torrent_information(html_body)
-      Torrent.save_torrent(torrent_struct)
-    end
-    queue
+    {:noreply, new_queue}
   end
 
   # Parser functions

--- a/lib/crawler/thepiratebay.ex
+++ b/lib/crawler/thepiratebay.ex
@@ -1,9 +1,8 @@
 defmodule Magnetissimo.Crawler.ThePirateBay do
   use GenServer
   alias Magnetissimo.Crawler.Helper
-  alias Magnetissimo.Torrent.T
+  alias Magnetissimo.Torrent
   require Logger
-
 
   def start_link do
     queue = initial_queue()
@@ -85,7 +84,7 @@ defmodule Magnetissimo.Crawler.ThePirateBay do
       |> Floki.text
       |> Integer.parse
 
-    %T{
+    %{
       name: name,
       magnet: magnet,
       size: size,

--- a/lib/crawler/thepiratebay.ex
+++ b/lib/crawler/thepiratebay.ex
@@ -14,7 +14,7 @@ defmodule Magnetissimo.Crawler.ThePirateBay do
   end
 
   defp schedule_work do
-    Process.send_after(self(), :work, 1 * 1 * 100) # 5 seconds
+    Process.send_after(self(), :work, 5000) # 5 seconds
   end
 
   # Callbacks

--- a/lib/crawler/torrentdownloads.ex
+++ b/lib/crawler/torrentdownloads.ex
@@ -54,14 +54,14 @@ defmodule Magnetissimo.Crawler.TorrentDownloads do
     :queue.from_list(urls)
   end
 
-  def torrent_links(html_body) do
+  def torrent_links(html_body) when is_binary(html_body) do
     html_body
     |> Floki.find(".grey_bar3 p a")
     |> Floki.attribute("href")
     |> Enum.map(fn(url) -> "https://www.torrentdownloads.me" <> url end)
   end
 
-  def torrent_information(html_body) do
+  def torrent_information(html_body) when is_binary(html_body) do
     name = html_body
       |> Floki.find("h1.titl_1 span")
       |> Floki.text

--- a/lib/crawler/torrentdownloads.ex
+++ b/lib/crawler/torrentdownloads.ex
@@ -1,7 +1,7 @@
-defmodule Magnetissimo.Crawler.TorrentDownloads do
+defmodule Magnetissimo.Crawler.Torrent.TDownloads do
   use GenServer
   alias Magnetissimo.Crawler.Helper
-  
+  alias Magnetissimo.Torrent.T 
   require Logger
 
   def start_link do
@@ -27,7 +27,7 @@ defmodule Magnetissimo.Crawler.TorrentDownloads do
       {{_value, {:torrent_link, url}}, queue_2} ->
         Helper.process({:torrent_link, url}, queue_2, fn x -> torrent_information(x) end)
       _ ->
-        Logger.debug "[Torrent Downloads] Queue is empty - restarting queue."
+        Logger.debug "[Torrent.T Downloads] Queue is empty - restarting queue."
         initial_queue()
     end
     schedule_work()
@@ -61,6 +61,7 @@ defmodule Magnetissimo.Crawler.TorrentDownloads do
     |> Enum.map(fn(url) -> "https://www.torrentdownloads.me" <> url end)
   end
 
+  @spec torrent_information(String.t) :: T.t
   def torrent_information(html_body) when is_binary(html_body) do
     name = html_body
       |> Floki.find("h1.titl_1 span")
@@ -106,7 +107,7 @@ defmodule Magnetissimo.Crawler.TorrentDownloads do
       |> String.trim
       |> Integer.parse
 
-    %{
+    %T{
       name: name,
       magnet: magnet,
       size: size,

--- a/lib/crawler/torrentdownloads.ex
+++ b/lib/crawler/torrentdownloads.ex
@@ -1,7 +1,8 @@
 defmodule Magnetissimo.Crawler.TorrentDownloads do
   use GenServer
-  alias Magnetissimo.Torrent
   alias Magnetissimo.Crawler.Helper
+  
+  require Logger
 
   def start_link do
     queue = initial_queue()
@@ -20,39 +21,19 @@ defmodule Magnetissimo.Crawler.TorrentDownloads do
   # Callbacks
 
   def handle_info(:work, queue) do
-    case :queue.out(queue) do
-      {{_value, item}, queue_2} ->
-        queue = queue_2
-        queue = process(item, queue)
+    new_queue = case :queue.out(queue) do
+      {{_value, {:page_link, url}}, queue_2} ->
+        Helper.process({:page_link, url}, queue_2, fn x -> torrent_links(x) end)
+      {{_value, {:torrent_link, url}}, queue_2} ->
+        Helper.process({:torrent_link, url}, queue_2, fn x -> torrent_information(x) end)
       _ ->
-        IO.puts "Queue is empty - restarting queue."
-        queue = initial_queue()
+        Logger.debug "[Torrent Downloads] Queue is empty - restarting queue."
+        initial_queue()
     end
     schedule_work()
-    {:noreply, queue}
+    {:noreply, new_queue}
   end
 
-  def process({:page_link, url}, queue) do
-    IO.puts "Downloading page: #{url}"
-    html_body = Helper.download(url)
-    if html_body != nil do
-      torrents = torrent_links(html_body)
-      queue = Enum.reduce(torrents, queue, fn torrent, queue ->
-        :queue.in({:torrent_link, torrent}, queue)
-      end)
-    end
-    queue
-  end
-
-  def process({:torrent_link, url}, queue) do
-    IO.puts "Downloading torrent: #{url}"
-    html_body = Helper.download(url)
-    if html_body != nil do
-      torrent_struct = torrent_information(html_body)
-      Torrent.save_torrent(torrent_struct)
-    end
-    queue
-  end
 
   # Parser functions
 

--- a/lib/crawler/torrentdownloads.ex
+++ b/lib/crawler/torrentdownloads.ex
@@ -4,7 +4,7 @@ defmodule Magnetissimo.Crawler.TorrentDownloads do
   alias Magnetissimo.Crawler.Helper
 
   def start_link do
-    queue = initial_queue
+    queue = initial_queue()
     GenServer.start_link(__MODULE__, queue)
   end
 
@@ -26,7 +26,7 @@ defmodule Magnetissimo.Crawler.TorrentDownloads do
         queue = process(item, queue)
       _ ->
         IO.puts "Queue is empty - restarting queue."
-        queue = initial_queue
+        queue = initial_queue()
     end
     schedule_work()
     {:noreply, queue}

--- a/lib/crawler/torrentdownloads.ex
+++ b/lib/crawler/torrentdownloads.ex
@@ -1,7 +1,7 @@
-defmodule Magnetissimo.Crawler.Torrent.TDownloads do
+defmodule Magnetissimo.Crawler.TorrentDownloads do
   use GenServer
   alias Magnetissimo.Crawler.Helper
-  alias Magnetissimo.Torrent.T 
+  alias Magnetissimo.Torrent 
   require Logger
 
   def start_link do
@@ -107,7 +107,7 @@ defmodule Magnetissimo.Crawler.Torrent.TDownloads do
       |> String.trim
       |> Integer.parse
 
-    %T{
+    %{
       name: name,
       magnet: magnet,
       size: size,

--- a/lib/crawler/worldwidetorrents.ex
+++ b/lib/crawler/worldwidetorrents.ex
@@ -2,6 +2,7 @@ defmodule Magnetissimo.Crawler.WorldWideTorrents do
   use GenServer
   alias Magnetissimo.Torrent
   alias Magnetissimo.Crawler.Helper
+  require Logger
 
   def start_link do
     queue = initial_queue()
@@ -20,18 +21,18 @@ defmodule Magnetissimo.Crawler.WorldWideTorrents do
   # Callbacks
 
   def handle_info(:work, queue) do
-    case :queue.out(queue) do
+    new_queue = case :queue.out(queue) do
       {{_value, item}, queue_2} ->
-        queue = queue_2
-        queue = process(item, queue)
+        process(item, queue_2)
       _ ->
-        IO.puts "Queue is empty - restarting queue."
-        queue = initial_queue()
+        Logger.debug "[World Wide Torrents] Queue is empty - restarting queue."
+        initial_queue()
     end
     schedule_work()
-    {:noreply, queue}
+    {:noreply, new_queue}
   end
 
+  # Custom process function.
   def process({:page_link, url}, queue) do
     IO.puts "Downloading page: #{url}"
     html_body = Helper.download(url)

--- a/lib/crawler/worldwidetorrents.ex
+++ b/lib/crawler/worldwidetorrents.ex
@@ -4,7 +4,7 @@ defmodule Magnetissimo.Crawler.WorldWideTorrents do
   alias Magnetissimo.Crawler.Helper
 
   def start_link do
-    queue = initial_queue
+    queue = initial_queue()
     GenServer.start_link(__MODULE__, queue)
   end
 
@@ -26,7 +26,7 @@ defmodule Magnetissimo.Crawler.WorldWideTorrents do
         queue = process(item, queue)
       _ ->
         IO.puts "Queue is empty - restarting queue."
-        queue = initial_queue
+        queue = initial_queue()
     end
     schedule_work()
     {:noreply, queue}

--- a/lib/crawler/worldwidetorrents.ex
+++ b/lib/crawler/worldwidetorrents.ex
@@ -61,7 +61,7 @@ defmodule Magnetissimo.Crawler.WorldWideTorrents do
     torrents
   end
 
-  def parse_row(row) when is_binary(row) do
+  def parse_row(row) when is_tuple(row) do
     name = row
       |> Floki.find("td")
       |> Enum.at(0)

--- a/lib/crawler/worldwidetorrents.ex
+++ b/lib/crawler/worldwidetorrents.ex
@@ -1,5 +1,6 @@
-defmodule Magnetissimo.Crawler.WorldWideTorrents do
+defmodule Magnetissimo.Crawler.WorldWideTorrent.Ts do
   use GenServer
+  alias Magnetissimo.Torrent.T
   alias Magnetissimo.Torrent
   alias Magnetissimo.Crawler.Helper
   require Logger
@@ -25,7 +26,7 @@ defmodule Magnetissimo.Crawler.WorldWideTorrents do
       {{_value, item}, queue_2} ->
         process(item, queue_2)
       _ ->
-        Logger.debug "[World Wide Torrents] Queue is empty - restarting queue."
+        Logger.debug "[World Wide Torrent.Ts] Queue is empty - restarting queue."
         initial_queue()
     end
     schedule_work()
@@ -45,7 +46,7 @@ defmodule Magnetissimo.Crawler.WorldWideTorrents do
 
   # Parser functions
 
-  # WorldWideTorrents offers all of it's content on it's pagination page.
+  # WorldWideTorrent.Ts offers all of it's content on it's pagination page.
   # There's no need to go into a torrent detail page.
   def initial_queue do
     urls = for i <- 1..50 do
@@ -61,6 +62,7 @@ defmodule Magnetissimo.Crawler.WorldWideTorrents do
     torrents
   end
 
+  @spec parse_row(tuple()) :: T.t
   def parse_row(row) when is_tuple(row) do
     name = row
       |> Floki.find("td")
@@ -97,7 +99,7 @@ defmodule Magnetissimo.Crawler.WorldWideTorrents do
       |> Floki.text
       |> String.replace(",", "")
 
-    %{
+    %T{
       name: name,
       magnet: magnet,
       size: size,

--- a/lib/crawler/worldwidetorrents.ex
+++ b/lib/crawler/worldwidetorrents.ex
@@ -54,14 +54,14 @@ defmodule Magnetissimo.Crawler.WorldWideTorrents do
     :queue.from_list(urls)
   end
 
-  def torrent_information(html_body) do
+  def torrent_information(html_body) when is_binary(html_body) do
     torrents = html_body
       |> Floki.find(".ttable_headinner .t-row")
       |> Enum.map(fn(row) -> parse_row(row) end)
     torrents
   end
 
-  def parse_row(row) do
+  def parse_row(row) when is_binary(row) do
     name = row
       |> Floki.find("td")
       |> Enum.at(0)

--- a/lib/crawler/worldwidetorrents.ex
+++ b/lib/crawler/worldwidetorrents.ex
@@ -1,6 +1,5 @@
-defmodule Magnetissimo.Crawler.WorldWideTorrent.Ts do
+defmodule Magnetissimo.Crawler.WorldWideTorrents do
   use GenServer
-  alias Magnetissimo.Torrent.T
   alias Magnetissimo.Torrent
   alias Magnetissimo.Crawler.Helper
   require Logger
@@ -99,7 +98,7 @@ defmodule Magnetissimo.Crawler.WorldWideTorrent.Ts do
       |> Floki.text
       |> String.replace(",", "")
 
-    %T{
+    %{
       name: name,
       magnet: magnet,
       size: size,

--- a/lib/magnetissimo.ex
+++ b/lib/magnetissimo.ex
@@ -1,6 +1,7 @@
 defmodule Magnetissimo do
   use Application
 
+  @strategy [restart: :permanent]
   # See http://elixir-lang.org/docs/stable/elixir/Application.html
   # for more information on OTP Applications
   def start(_type, _args) do
@@ -9,18 +10,18 @@ defmodule Magnetissimo do
     # Define workers and child supervisors to be supervised
     children = [
       # Start the Ecto repository
-      supervisor(Magnetissimo.Repo, []),
+      supervisor(Magnetissimo.Repo, [], @strategy),
       # Start the endpoint when the application starts
-      supervisor(Magnetissimo.Endpoint, []),
+      supervisor(Magnetissimo.Endpoint, [], @strategy),
       # Start your own worker by calling: Magnetissimo.Worker.start_link(arg1, arg2, arg3)
-      worker(Magnetissimo.Crawler.ThePirateBay,      []),
-      worker(Magnetissimo.Crawler.EZTV,              []),
-      worker(Magnetissimo.Crawler.LimeTorrents,      []),
-      worker(Magnetissimo.Crawler.Leetx,             []),
-      worker(Magnetissimo.Crawler.Monova,            []),
-      worker(Magnetissimo.Crawler.TorrentDownloads,  []),
-      worker(Magnetissimo.Crawler.WorldWideTorrents, []),
-      # worker(Magnetissimo.Crawler.Demonoid, []), # Down until Demonoid solve their hosting issues.
+      worker(Magnetissimo.Crawler.ThePirateBay,      [], @strategy),
+      worker(Magnetissimo.Crawler.EZTV,              [], @strategy),
+      worker(Magnetissimo.Crawler.LimeTorrents,      [], @strategy),
+      worker(Magnetissimo.Crawler.Leetx,             [], @strategy),
+      worker(Magnetissimo.Crawler.Monova,            [], @strategy),
+      worker(Magnetissimo.Crawler.TorrentDownloads,  [], @strategy),
+      worker(Magnetissimo.Crawler.WorldWideTorrents, [], @strategy),
+      # worker(Magnetissimo.Crawler.Demonoid, [], @strategy), # Down until Demonoid solve their hosting issues.
     ]
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html

--- a/mix.exs
+++ b/mix.exs
@@ -38,13 +38,13 @@ defmodule Magnetissimo.Mixfile do
      {:phoenix_live_reload, "~> 1.0", only: :dev},
      {:gettext, "~> 0.11"},
      {:cowboy, "~> 1.0"},
-     {:floki, "~> 0.11.0"},
+     {:floki, "~> 0.11.0", runtime: false},
      {:httpoison, "~> 0.10.0"},
-     {:html_entities, "~> 0.3"},
+     {:html_entities, "~> 0.3", runtime: false},
      {:distillery, "~> 1.0"},
      {:scrivener_ecto, "~> 1.0"},
      {:scrivener_html, "~> 1.1"},
-     {:sizeable, "~> 0.1.5"}]
+     {:sizeable, "~> 0.1.5", runtime: false}]
   end
 
   # Aliases are shortcuts or tasks specific to the current project.

--- a/web/models/torrent.ex
+++ b/web/models/torrent.ex
@@ -4,6 +4,23 @@ defmodule Magnetissimo.Torrent do
   alias Magnetissimo.Repo
   alias Magnetissimo.Torrent
 
+  @type t :: %Magnetissimo.T{magnet:         String.t,
+                             seeders:        non_neg_integer(),
+                             leechers:       non_neg_integer(),
+                             name:           String.t,
+                             website_source: String.t,
+                             size:           String.t
+                            }
+
+  @derive [String.Chars]
+  defstruct [ :magnet,
+              :seeders,
+              :leechers,
+              :name,
+              :website_source,
+              :size
+          ]
+
   schema "torrents" do
     field :magnet, :string
     field :seeders, :integer
@@ -15,6 +32,8 @@ defmodule Magnetissimo.Torrent do
     timestamps()
   end
 
+
+end
   @doc """
   Builds a changeset based on the `struct` and `params`.
   """

--- a/web/models/torrent.ex
+++ b/web/models/torrent.ex
@@ -4,22 +4,24 @@ defmodule Magnetissimo.Torrent do
   alias Magnetissimo.Repo
   alias Magnetissimo.Torrent
 
-  @type t :: %Magnetissimo.T{magnet:         String.t,
-                             seeders:        non_neg_integer(),
-                             leechers:       non_neg_integer(),
-                             name:           String.t,
-                             website_source: String.t,
-                             size:           String.t
-                            }
+  defmodule T do
+    defstruct [ :magnet,
+                :seeders,
+                :leechers,
+                :name,
+                :website_source,
+                :size
+              ]
 
-  @derive [String.Chars]
-  defstruct [ :magnet,
-              :seeders,
-              :leechers,
-              :name,
-              :website_source,
-              :size
-          ]
+  @type t :: %Magnetissimo.Torrent.T{magnet:         String.t,
+                                     seeders:        non_neg_integer(),
+                                     leechers:       non_neg_integer(),
+                                     name:           String.t,
+                                     website_source: String.t,
+                                     size:           String.t
+                                    }
+
+  end
 
   schema "torrents" do
     field :magnet, :string
@@ -33,7 +35,6 @@ defmodule Magnetissimo.Torrent do
   end
 
 
-end
   @doc """
   Builds a changeset based on the `struct` and `params`.
   """

--- a/web/models/torrent.ex
+++ b/web/models/torrent.ex
@@ -4,25 +4,6 @@ defmodule Magnetissimo.Torrent do
   alias Magnetissimo.Repo
   alias Magnetissimo.Torrent
 
-  defmodule T do
-    defstruct [ :magnet,
-                :seeders,
-                :leechers,
-                :name,
-                :website_source,
-                :size
-              ]
-
-  @type t :: %Magnetissimo.Torrent.T{magnet:         String.t,
-                                     seeders:        non_neg_integer(),
-                                     leechers:       non_neg_integer(),
-                                     name:           String.t,
-                                     website_source: String.t,
-                                     size:           String.t
-                                    }
-
-  end
-
   schema "torrents" do
     field :magnet, :string
     field :seeders, :integer
@@ -34,6 +15,14 @@ defmodule Magnetissimo.Torrent do
     timestamps()
   end
 
+
+@type t :: %{magnet:         String.t,
+             seeders:        non_neg_integer(),
+             leechers:       non_neg_integer(),
+             name:           String.t,
+             website_source: String.t,
+             size:           String.t
+            }
 
   @doc """
   Builds a changeset based on the `struct` and `params`.


### PR DESCRIPTION
This PR is a bit big, so here's what I did: 

* I fixed almost *all* compiler warnings, related to variable expansion to function (`initial_queue` → `initial_queue()`).
* In order to do so efficiently, I moved the `process` function implemented by each crawler to the `Helper` module…
* … And in order to keep it working, I changed its arity from `2` to `3`. Since it had to use a module-specific implementation of `torrent_links/1` and `torrent_information/1`, I went the functional path: those functions are now passed as a 3rd argument to the `process/3` function.
* I added function guards to `torrent_information` and `torrent_links`.
* Enabled a restart strategy for the crawlers (	e8135a2).
* Dirty-patched several Match Errors.
* I added a type (`Torrent.t`) for typespecs.