### PR TITLE
LimeTorrents fix.

### DIFF
--- a/lib/crawler/helper.ex
+++ b/lib/crawler/helper.ex
@@ -30,7 +30,7 @@ defmodule Magnetissimo.Crawler.Helper do
         nil
 
       {:error, error} ->
-        Logger.error inspect(error)
+        Logger.error inspect(error.reason)
         nil
     end
   end

--- a/lib/crawler/limetorrents.ex
+++ b/lib/crawler/limetorrents.ex
@@ -4,7 +4,7 @@ defmodule Magnetissimo.Crawler.LimeTorrents do
   alias Magnetissimo.Crawler.Helper
 
   def start_link do
-    queue = initial_queue
+    queue = initial_queue()
     GenServer.start_link(__MODULE__, queue)
   end
 
@@ -20,33 +20,39 @@ defmodule Magnetissimo.Crawler.LimeTorrents do
   # Callbacks
 
   def handle_info(:work, queue) do
-    case :queue.out(queue) do
+    new_queue = case :queue.out(queue) do
       {{_value, item}, queue_2} ->
-        queue = queue_2
-        queue = process(item, queue)
+        process(item, queue_2)
       _ ->
         IO.puts "Queue is empty - restarting queue."
-        queue = initial_queue
     end
     schedule_work()
-    {:noreply, queue}
+    {:noreply, new_queue}
   end
 
   def process({:page_link, url}, queue) do
     IO.puts "Downloading page: #{url}"
     torrents = Helper.download(url) |> torrent_links
-    queue = Enum.reduce(torrents, queue, fn torrent, queue ->
-      :queue.in({:torrent_link, torrent}, queue)
-    end)
+    cond do
+      is_nil(torrents) -> nil
+      true -> queue = Enum.reduce(torrents, queue, fn torrent, queue ->
+                :queue.in({:torrent_link, torrent}, queue)
+              end)
+    end
     queue
   end
 
   def process({:torrent_link, url}, queue) do
     IO.puts "Downloading torrent: #{url}"
     html_body = Helper.download(url)
-    if String.length(html_body) > 300 do
-      torrent_struct = torrent_information(html_body)
-      Torrent.save_torrent(torrent_struct)
+    cond do
+      is_nil(html_body)    -> nil
+
+      is_binary(html_body) ->
+        torrent_struct = torrent_information(html_body)
+        Torrent.save_torrent(torrent_struct)
+
+      true                 -> nil
     end
     queue
   end
@@ -69,7 +75,11 @@ defmodule Magnetissimo.Crawler.LimeTorrents do
     :queue.from_list(urls)
   end
 
-  def torrent_links(html_body) do
+  @spec torrent_links(nil) :: nil
+  @spec torrent_links(String.t) :: list(String.t)
+
+  def torrent_links(nil), do: nil
+  def torrent_links(html_body) when is_binary(html_body) do
     html_body
     |> Floki.find(".tt-name a")
     |> Enum.drop_every(2)
@@ -77,7 +87,7 @@ defmodule Magnetissimo.Crawler.LimeTorrents do
     |> Enum.map(fn(url) -> "https://www.limetorrents.cc" <> url end)
   end
 
-  def torrent_information(html_body) do
+  def torrent_information(html_body) when is_binary(html_body) do
     name = html_body
       |> Floki.find("h1")
       |> Floki.text


### PR DESCRIPTION
This commit fixes the LimeTorrents crawler, with additional checks for the `nil` value that occasionnally gets passed to `Floki`.