### PR TITLE
Add nyaa.si crawler

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,4 @@ Magnetissimo currently fetches torrents from the following sites:
 - [x] ThePirateBay
 - [x] TorrentDownloads
 - [x] WorldWide Torrents
+- [x] Nyaa.si

--- a/lib/crawler/nyaa.ex
+++ b/lib/crawler/nyaa.ex
@@ -1,0 +1,120 @@
+defmodule Magnetissimo.Crawler.NyaaSi do
+  use GenServer
+  alias Magnetissimo.Torrent
+  alias Magnetissimo.Crawler.Helper
+  require Logger
+
+  def start_link do
+    queue = initial_queue()
+    GenServer.start_link(__MODULE__, queue)
+  end
+
+  def init(queue) do
+    schedule_work()
+    {:ok, queue}
+  end
+
+  defp schedule_work do
+    Process.send_after(self(), :work, 1 * 1 * 100) # 5 seconds
+  end
+
+  # Callbacks
+
+  def handle_info(:work, queue) do
+    case :queue.out(queue) do
+      {{_value, item}, queue_2} ->
+        queue = queue_2
+        queue = process(item, queue)
+      _ ->
+        Logger.debug "[Nyaa] Queue is empty - restarting queue."
+        queue = initial_queue()
+    end
+    schedule_work()
+    {:noreply, queue}
+  end
+
+  def process({:page_link, url}, queue) do
+    Logger.info "[Nyaa] Downloading page: #{url}"
+    html_body = Helper.download(url)
+    if html_body != nil do
+      torrents = torrent_links(html_body)
+      queue = Enum.reduce(torrents, queue, fn torrent, queue ->
+        :queue.in({:torrent_link, torrent}, queue)
+      end)
+    else
+      Logger.warn "[Nyaa] html_body is nil"
+    end
+    queue
+  end
+
+  def process({:torrent_link, url}, queue) do
+    Logger.info "[Nyaa] Downloading torrent: #{url}"
+    html_body = Helper.download(url)
+    if html_body != nil do
+      torrent_struct = torrent_information(html_body)
+      Torrent.save_torrent(torrent_struct)
+    else
+      Logger.warn "[Nyaa] html_body is nil"
+    end
+    queue
+  end
+
+  # Parser functions
+
+  def initial_queue do
+    urls = for i <- 1..50 do
+      {:page_link, "https://nyaa.si/?p=#{i}"}
+    end
+    :queue.from_list(urls)
+  end
+
+  def torrent_links(html_body) do
+    Logger.debug "[Nyaa] Extracting Torrents"
+    html_body
+    |> Floki.find(".default td[colspan=\"2\"] a")
+    |> Floki.attribute("href")
+    |> Enum.filter(fn(url) -> String.starts_with?(url, "/view/") end)
+    |> Enum.map(fn(url) -> "https://nyaa.si" <> url end)
+  end
+
+  def torrent_information(html_body) do
+    name = html_body
+      |> Floki.find("h3.panel-title")
+      |> Enum.at(0)
+      |> Floki.text
+      |> String.trim
+      |> HtmlEntities.decode
+
+    magnet = html_body
+      |> Floki.find("div.panel-footer a")
+      |> Floki.attribute("href")
+      |> Enum.filter(fn(url) -> String.starts_with?(url, "magnet:") end)
+      |> Enum.at(0)
+
+    size = html_body
+      |> Floki.find("div.panel-body .row:nth-child(4) div.col-md-5")
+      |> Enum.at(0)
+      |> Floki.text
+
+    {seeders, _} = html_body
+      |> Floki.find("div.panel-body .row:nth-child(2) div.col-md-5")
+      |> Enum.at(1)
+      |> Floki.text
+      |> Integer.parse
+
+    {leechers, _} = html_body
+      |> Floki.find("div.panel-body .row:nth-child(3) div.col-md-5")
+      |> Enum.at(1)
+      |> Floki.text
+      |> Integer.parse
+
+    %{
+      name: name,
+      magnet: magnet,
+      size: size,
+      website_source: "nyaa",
+      seeders: seeders,
+      leechers: leechers
+    }
+  end
+end

--- a/lib/magnetissimo.ex
+++ b/lib/magnetissimo.ex
@@ -21,6 +21,7 @@ defmodule Magnetissimo do
       worker(Magnetissimo.Crawler.TorrentDownloads,  []),
       worker(Magnetissimo.Crawler.WorldWideTorrents, []),
       # worker(Magnetissimo.Crawler.Demonoid, []), # Down until Demonoid solve their hosting issues.
+      worker(Magnetissimo.Crawler.NyaaSi,            []),
     ]
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html

--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,7 @@ defmodule Magnetissimo.Mixfile do
      {:phoenix_live_reload, "~> 1.0", only: :dev},
      {:gettext, "~> 0.11"},
      {:cowboy, "~> 1.0"},
-     {:floki, "~> 0.11.0"},
+     {:floki, "~> 0.17.2"},
      {:httpoison, "~> 0.10.0"},
      {:html_entities, "~> 0.3"},
      {:distillery, "~> 1.0"},


### PR DESCRIPTION
This PR adds a crawler for nyaa.si, a clone of the recently deceased nyaa.se.

Site: https://nyaa.si
Source: https://github.com/nyaadevs/nyaa

The dependency on `floki` was changed to version 0.17.2 because of `:nth-child(n)` support in `Floki.find`