### PR TITLE
Fix EZTV tracker to use the RSS feeds at our disposal

### DIFF
--- a/lib/magnetissimo/contents.ex
+++ b/lib/magnetissimo/contents.ex
@@ -4,16 +4,16 @@ defmodule Magnetissimo.Contents do
   require Logger
   import Ecto.Query
 
-  def save_torrent(torrent) do
-    changeset = Torrent.changeset(%Torrent{}, torrent)
+  def save_torrent(attrs) do
+    changeset = Torrent.changeset(%Torrent{}, attrs)
     case Repo.insert(changeset) do
-      {:ok, _torrent} ->
+      {:ok, torrent} ->
         Logger.info "Torrent saved to database: #{torrent.name}"
       {:error, changeset} ->
         errors = for {key, {message, _}} <- changeset.errors do
           "#{key} #{message}"
         end
-        Logger.error "Torrent skipped: #{torrent.name} - Errors: #{Enum.join(errors, ", ")}"
+        Logger.error "Torrent skipped: #{attrs.name} - Errors: #{Enum.join(errors, ", ")}"
     end
   end
 

--- a/lib/magnetissimo/crawler/demonoid.ex
+++ b/lib/magnetissimo/crawler/demonoid.ex
@@ -11,7 +11,7 @@ defmodule Magnetissimo.Crawler.Demonoid do
 
   def initial_queue do
     urls = for i <- 1..5 do
-      {:page_link, "https://www.demonoid.pw/files/?to=0&uid=0&category=0&subcategory=0&language=0&seeded=2&quality=0&external=2&query=&sort=&page=#{i}"}
+      {:page_link, "https://www.demonoid.pw/rss/0.xml"}
     end
     :queue.from_list(urls)
   end

--- a/lib/magnetissimo/crawler/eztv.ex
+++ b/lib/magnetissimo/crawler/eztv.ex
@@ -57,7 +57,7 @@ defmodule Magnetissimo.Crawler.EZTV do
   end
 
   def torrent_information(item) do
-    attributes = [["title"], ["torrent:magneturi"], ["torrent:seeds"], ["torrent:peers"], ["link"]]
+    attributes = [["title"], ["torrent:magneturi"], ["torrent:seeds"], ["torrent:peers"], ["link"], ["torrent:contentlength"]]
     data = item
            |> Enum.map(fn f -> %{elem(f,0) => elem(f, 2)} end)
            |> Enum.filter(fn f -> Enum.member?(attributes, Map.keys(f)) end)
@@ -66,7 +66,7 @@ defmodule Magnetissimo.Crawler.EZTV do
     %{
       name: hd(data["title"]),
       magnet: hd(data["torrent:magneturi"]),
-      size: "0MB",
+      size: (data["torrent:contentlength"] |> hd |> Sizeable.filesize()),
       website_source: "eztv",
       seeders:  String.to_integer(hd(data["torrent:seeds"])),
       leechers: String.to_integer(hd(data["torrent:peers"])),

--- a/lib/magnetissimo/crawler/eztv.ex
+++ b/lib/magnetissimo/crawler/eztv.ex
@@ -1,19 +1,25 @@
 defmodule Magnetissimo.Crawler.EZTV do
   @moduledoc """
-  Torrent parser for EZTV in charge of scraping and saving
-  the latest torrents on the website.
+  Torrent parser for EZTV in charge of parsing the RSS feed
   """
 
-  @behaviour Magnetissimo.WebParser
   use GenServer
   require Logger
   import Magnetissimo.Crawler.Helper
+  alias Magnetissimo.Torrent
 
   def initial_queue do
-    urls = for i <- 0..4 do
-      {:page_link, "https://eztv.ag/page_#{i}"}
+    url = "https://eztv.ag/ezrss.xml"
+    case download(url) do
+      {:ok, body} ->
+        body
+        |> Floki.find("channel")
+        |> Floki.find("item")
+        |> Enum.map(fn x -> elem(x,2) end)
+      {:error, :wrong_headers} ->
+        Logger.error "[EZTV] Wrong headers in the HTTP Response!"
+        []
     end
-    :queue.from_list(urls)
   end
 
   def start_link(_) do
@@ -22,125 +28,49 @@ defmodule Magnetissimo.Crawler.EZTV do
   end
 
   def init(queue) do
-    schedule_work()
+    schedule_start()
     {:ok, queue}
   end
 
-  defp schedule_work do
-    wait_seconds = :rand.uniform(8) * 1000
-    Process.send_after(self(), :work, wait_seconds)
+  def schedule_start() do
+    wait = :rand.uniform(8) * 1000 # [1,8] seconds
+    Process.send_after(self(), :work, wait)
+  end
+
+  def schedule_work() do
+    wait = 1800000 # 30mn
+    Logger.info("[EZTV] Finished crawling the RSS feed, waiting 30 minutes…")
+    Process.send_after(self(), :work, wait)
   end
 
   def handle_info(:work, queue) do
-    new_queue =
-      case :queue.out(queue) do
-        {{_value, item}, queue_2} ->
-          process(item, queue_2)
-        _ ->
-          Logger.info "[EZTV] Queue is empty, restarting scraping procedure."
-          initial_queue()
-      end
-    schedule_work()
-    {:noreply, new_queue}
-  end
-
-  def process({:page_link, url}, queue) do
-    Logger.info "[EZTV] Finding torrents in listing page: #{url}"
-    result = download(url) |> torrent_links
-    case result do
-      {:error, message} ->
-        Logger.error message
-        queue
-      torrents ->
-        Enum.reduce(torrents, queue, fn torrent, queue ->
-          :queue.in({:torrent_link, torrent}, queue)
-        end)
-    end
-  end
-
-  def process({:torrent_link, url}, queue) do
-    Logger.info "[EZTV] Downloading torrent from page: #{url}"
-    result = download(url) |> torrent_information 
-    case result do
-      {:error, message} -> 
-        Logger.error message
-      torrent_struct -> 
-        torrent_struct = Map.put(torrent_struct, :outbound_url, url)
-        Magnetissimo.Torrent.save_torrent(torrent_struct)
-    end
     queue
+    |> Enum.each(&(process(&1)))
+    schedule_work()
+    {:noreply, initial_queue()}
   end
 
-  def torrent_links(html_body) when is_binary(html_body) and byte_size(html_body) > 50 do
-    html_body
-    |> Floki.find("a.epinfo")
-    |> Floki.attribute("href")
-    |> Enum.filter(fn(a) -> String.contains?(a, "/ep/") end)
-    |> Enum.map(fn(url) -> "https://eztv.ag" <> url end)
+  def process(item) do
+    item
+    |> torrent_information
+    |> Torrent.save_torrent()
   end
 
-  def torrent_links(_html_body) do
-    {:error, "Couldn't parse torrents links."}
-  end
-
-  def torrent_information(html_body) when is_binary(html_body) and byte_size(html_body) > 50 do
-    name = html_body
-      |> Floki.find("td.section_post_header")
-      |> Enum.at(0)
-      |> Floki.text
-      |> String.trim
-      |> HtmlEntities.decode
-
-    magnet = html_body
-      |> Floki.find("a")
-      |> Floki.attribute("href")
-      |> Enum.filter(fn(url) -> String.starts_with?(url, "magnet:") end)
-      |> Enum.at(0)
-
-    size_table = html_body
-      |> Floki.find("table")
-      |> Enum.at(8)
-      |> Floki.text
-      |> String.split(" ")
-
-    # unit = "MB"
-
-    size_value = case Enum.count(size_table) do
-      18 -> Enum.at(size_table, 6)
-      _  -> 0
-    end
-
-      unit = size_table
-        |> Enum.at(7)
-        |> String.split("\n")
-        |> Enum.at(0)  
-
-    seeders = html_body
-      |> Floki.find(".stat_red")
-      |> Enum.at(0)
-      |> Floki.text
-      |> String.trim
-
-    leechers = html_body
-      |> Floki.find(".stat_green")
-      |> Enum.at(0)
-      |> Floki.text
-      |> String.trim
-
-    size = size_to_bytes(size_value, unit) |> Kernel.to_string
+  def torrent_information(item) do
+    attributes = [["title"], ["torrent:magneturi"], ["torrent:seeds"], ["torrent:peers"], ["link"]]
+    data = item
+           |> Enum.map(fn f -> %{elem(f,0) => elem(f, 2)} end)
+           |> Enum.filter(fn f -> Enum.member?(attributes, Map.keys(f)) end)
+           |> Enum.reduce(fn(map, acc) -> Map.merge(map, acc) end)
 
     %{
-      name: name,
-      magnet: magnet,
-      size: size,
+      name: hd(data["title"]),
+      magnet: hd(data["torrent:magneturi"]),
+      size: "0MB",
       website_source: "eztv",
-      seeders: seeders,
-      leechers: leechers
+      seeders:  String.to_integer(hd(data["torrent:seeds"])),
+      leechers: String.to_integer(hd(data["torrent:peers"])),
+      outbound_url: hd(data["link"])
     }
   end
-
-  def torrent_information(_html_body) do
-    {:error, "Couldn't parse torrent information"}
-  end
-
 end

--- a/lib/magnetissimo/crawler/supervisor.ex
+++ b/lib/magnetissimo/crawler/supervisor.ex
@@ -13,11 +13,11 @@ defmodule Magnetissimo.Crawler.Supervisor do
   def init(_arg) do
     children = [
       # {Demonoid, []},
-      # {EZTV, []},
+      {EZTV, []},
       # {Leetx, []},
       # {Monova, []},
       # {ThePirateBay, []},
-      {TorrentDownloads, []},
+      # {TorrentDownloads, []},
       # {WorldWideTorrents, []},
       # {Zooqle, []},
     ]

--- a/lib/magnetissimo/torrent.ex
+++ b/lib/magnetissimo/torrent.ex
@@ -5,13 +5,13 @@ defmodule Magnetissimo.Torrent do
   alias Magnetissimo.{Contents,Torrent}
 
   schema "torrents" do
-    field :magnet,         :string
-    field :seeders,        :integer
     field :leechers,       :integer
+    field :magnet,         :string
     field :name,           :string
-    field :website_source, :string
-    field :size,           :string
     field :outbound_url,   :string
+    field :seeders,        :integer
+    field :size,           :string
+    field :website_source, :string
 
     timestamps()
   end
@@ -25,7 +25,7 @@ defmodule Magnetissimo.Torrent do
     |> validate_required([:magnet, :seeders, :leechers, :name, :website_source, :size, :outbound_url])
     |> validate_number(:seeders, greater_than_or_equal_to: 0)
     |> validate_number(:leechers, greater_than_or_equal_to: 0)
-    |> unique_constraint(:magnet)
+    |> unique_constraint(:magnet, name: :unique_magnet_name)
   end
 
   defdelegate save_torrent(torrent),                   to: Contents

--- a/priv/repo/migrations/20171222185511_create_torrents.exs
+++ b/priv/repo/migrations/20171222185511_create_torrents.exs
@@ -3,18 +3,19 @@ defmodule Magnetissimo.Repo.Migrations.Createtorrents do
 
   def change do
     create table(:torrents) do
-      add :leechers, :integer
-      add :magnet, :text
-      add :name, :text
-      add :outbound_url, :string
-      add :seeders, :integer
-      add :size, :string
-      add :website_source, :string
+      add :leechers, :integer, null: false
+      add :magnet, :text, null: false
+      add :name, :text, null: false
+      add :outbound_url, :string, null: false
+      add :seeders, :integer, null: false
+      add :size, :string, null: false
+      add :website_source, :string, null: false
 
       timestamps()
     end
 
     create index(:torrents, [:name])
     create index(:torrents, [:website_source])
+    create unique_index(:torrents, [:magnet, :name], name: :unique_magnet_name)
   end
 end


### PR DESCRIPTION
Here is an overview of the changes:

* We are now using the RSS endpoint
* Parsing is still done with Floki (The best at parsing XML and providing a simple and efficient API to work with)
* No need to make ourselves undesirable, once the RSS is consumed, Magnetissimo will wait 30 minutes before consuming it again. In practice we're not missing many torrents, if at all.
* One big disadvantage is that we're now lacking informations about the number of leechers and seeders of the torrents. This will have to be implemented in another PR, if the folks at EZTV don't fix their RSS. I'll try to contact them on that issue. 
