### PR TITLE
add xbit api crawler

### DIFF
--- a/lib/magnetissimo/crawler/helper.ex
+++ b/lib/magnetissimo/crawler/helper.ex
@@ -2,7 +2,7 @@ defmodule Magnetissimo.Crawler.Helper do
   require Logger
   use Tesla
 
-  plug Tesla.Middleware.Headers, %{"Accept" => "text/html,text/xml,application/xhtml+xml,application/xml"}
+  plug Tesla.Middleware.Headers, %{"Accept" => "text/html,text/xml,application/xhtml+xml,application/xml,application/json"}
   plug Tesla.Middleware.Opts, [recv_timeout: :infinity]
   plug Tesla.Middleware.FollowRedirects, max_redirects: 10
 
@@ -55,7 +55,7 @@ defmodule Magnetissimo.Crawler.Helper do
 
   @spec verify_mime(String.t) :: :ok | {:error, :wrong_headers}
   defp verify_mime(types) do
-    case Regex.run(~r/^(?:text|application)\/(?:html|xml|xhtml).*/iu, types, capture: :all_but_first) do
+    case Regex.run(~r/^(?:text|application)\/(?:html|json|xml|xhtml).*/iu, types, capture: :all_but_first) do
       nil -> {:error, :wrong_headers}
       _   -> :ok
     end

--- a/lib/magnetissimo/crawler/supervisor.ex
+++ b/lib/magnetissimo/crawler/supervisor.ex
@@ -4,7 +4,7 @@ defmodule Magnetissimo.Crawler.Supervisor do
   alias Magnetissimo.Crawler.{Demonoid, EZTV, Leetx, Monova,
                               NyaaPantsu, NyaaSi,
                               ThePirateBay, TorrentDownloads,
-                              WorldWideTorrents, Zooqle}
+                              WorldWideTorrents, XBit, Zooqle}
 
   def start_link(arg) do
     Logger.info IO.ANSI.magenta <> "Starting Crawler Supervisor" <> IO.ANSI.reset
@@ -22,6 +22,7 @@ defmodule Magnetissimo.Crawler.Supervisor do
       # {ThePirateBay, []},
       # {TorrentDownloads, []},
       # {WorldWideTorrents, []},
+      {XBit, []},
       {Zooqle, []},
     ]
 

--- a/lib/magnetissimo/crawler/xbit.ex
+++ b/lib/magnetissimo/crawler/xbit.ex
@@ -1,0 +1,103 @@
+defmodule Magnetissimo.Crawler.XBit do
+  @moduledoc """
+  Torrent parser for xBit in charge of parsing the API
+  """
+
+  use GenServer
+  require Logger
+  require Poison
+  import Magnetissimo.Crawler.Helper
+  alias Magnetissimo.Torrent
+
+  def initial_queue do
+    url = "https://xbit.pw/api"
+    case download(url) do
+      {:ok, body} ->
+        body
+        |> Poison.decode
+        |> case do
+          {:ok, data} ->
+            data["dht_results"]
+          {:error, msg} ->
+            Logger.error "[xBit] #{inspect msg}"
+            []
+          end
+      {:error, :wrong_headers} ->
+        Logger.error "[xBit] Wrong headers in the HTTP Response!"
+        []
+    end
+  end
+
+  def start_link(_) do
+    queue = initial_queue()
+    GenServer.start_link(__MODULE__, queue, name: __MODULE__)
+  end
+
+  def init(queue) do
+    Logger.info IO.ANSI.magenta <> "Starting xBit crawler" <> IO.ANSI.reset
+    schedule_start()
+    {:ok, queue}
+  end
+
+  def schedule_start() do
+    wait = :rand.uniform(8) * 1000 # [1,8] seconds
+    Process.send_after(self(), :work, wait)
+  end
+
+  def schedule_work() do
+    wait = 1800000 # 30mn
+    Logger.info("[xBit] Finished crawling the RSS feed, waiting 30 minutes…")
+    Process.send_after(self(), :work, wait)
+  end
+
+  def handle_info(:work, queue) do
+    queue
+    |> Enum.each(&(process(&1)))
+    schedule_work()
+    {:noreply, initial_queue()}
+  end
+
+  def process(item) do
+    case item["NAME"] do
+      nil -> nil # xBit includes an empty entry at the end of dht_results
+      _ ->
+        item
+        |> torrent_information
+        |> Torrent.save_torrent()
+      end
+  end
+
+  defp fix_size(size) do
+    {number_part, unit_part} = Float.parse size
+    fixed_size = case String.trim(unit_part) do
+      "PB" ->
+        number_part * :math.pow(1024, 5)
+      "TB" ->
+        number_part * :math.pow(1024, 4)
+      "GB" ->
+        number_part * :math.pow(1024, 3)
+      "MB" ->
+        number_part * :math.pow(1024, 2)
+      "kB" ->
+        number_part * :math.pow(1024, 1)
+      "B" ->
+        number_part
+    end
+
+    fixed_size
+      |> round
+      |> Integer.to_string
+  end
+
+  def torrent_information(item) do
+    %{
+      name: item["NAME"],
+      magnet: item["MAGNET"],
+      size: (item["SIZE"] |> fix_size),
+      website_source: "xbit",
+      seeders:  0,
+      leechers: 0,
+      outbound_url: "https://xbit.pw/?id=#{item["ID"]}"
+    }
+  end
+end

--- a/lib/magnetissimo/crawler/xbit.ex
+++ b/lib/magnetissimo/crawler/xbit.ex
@@ -12,7 +12,7 @@ defmodule Magnetissimo.Crawler.XBit do
   def initial_queue do
     url = "https://xbit.pw/api"
     with {:ok, body} <- download(url),
-         {:ok, data} <- Poison.decode(body)
+         {:ok, data} <- Poison.decode(escape(body))
     do
       data["dht_results"]
     else
@@ -88,6 +88,7 @@ defmodule Magnetissimo.Crawler.XBit do
   end
 
   def escape(blob) do
+    # xBit's api sometimes returns invalid JSON, so we make a feeble attempt to fix it
     blob
       |> String.replace("\\", "\\\\")
   end

--- a/lib/magnetissimo_web/templates/layout/app.html.eex
+++ b/lib/magnetissimo_web/templates/layout/app.html.eex
@@ -85,6 +85,14 @@
             </li>
             <li class="menu-item">
               <div class="menu-badge">
+                <label class="label label-primary"><%= Magnetissimo.Torrent.total_by_website_source("xbit") %></label>
+              </div>
+              <a href="#">
+                xBit
+              </a>
+            </li>
+            <li class="menu-item">
+              <div class="menu-badge">
                 <label class="label label-primary"><%= Magnetissimo.Torrent.total_by_website_source("zooqle") %></label>
               </div>
               <a href="#">


### PR DESCRIPTION
The xBit crawler is based on the EZTV one, but uses the JSON API instead of an RSS feed because of encoding errors in the feed.

I had to copy and modify the `fix_size` function from the NyaaSi crawler to get the sizes in a usable format, so it seems like there's a need for a proper general solution to be used everywhere, instead of reimplementing it as-needed. I didn't write it here because it's out of scope (and probably deserving of its own library).

There's a bug in the xBit API which adds an empty torrent at the end of the `dht_results` list, which necessitated a workaround, explaining the odd-looking case in `process`.

There's no way to limit how many results we get back from the API (despite the documentation disagreeing), so we always scrape 1000 torrents at a time.
  
fix #86 