### PR TITLE
Fix torrent provider alignment issue

### DIFF
--- a/assets/css/spectre.css
+++ b/assets/css/spectre.css
@@ -2149,7 +2149,6 @@ code {
 }
 .menu .menu-badge {
   float: right;
-  padding: .6rem 0;
 }
 .menu .menu-badge .btn {
   margin-top: -.2rem;


### PR DESCRIPTION
This should fix the alignment issues in the list of torrent providers.

Why was the "padding: .6rem 0;"  added in the first place?