### PR TITLE
Rewrite zooqle scraper to use RSS

### DIFF
--- a/lib/magnetissimo/crawler/helper.ex
+++ b/lib/magnetissimo/crawler/helper.ex
@@ -2,7 +2,7 @@ defmodule Magnetissimo.Crawler.Helper do
   require Logger
   use Tesla
 
-  plug Tesla.Middleware.Headers, %{"Accept" => "text/html,text/xml,application/xhtml+xml,application/xml,application/json"}
+  plug Tesla.Middleware.Headers, %{"Accept" => "text/html,text/xml,application/xhtml+xml,application/xml,application/rss+xml,application/json"}
   plug Tesla.Middleware.Opts, [recv_timeout: :infinity]
   plug Tesla.Middleware.FollowRedirects, max_redirects: 10
 
@@ -55,7 +55,7 @@ defmodule Magnetissimo.Crawler.Helper do
 
   @spec verify_mime(String.t) :: :ok | {:error, :wrong_headers}
   defp verify_mime(types) do
-    case Regex.run(~r/^(?:text|application)\/(?:html|json|xml|xhtml).*/iu, types, capture: :all_but_first) do
+    case Regex.run(~r/^(?:text|application|applicaton)\/(?:html|json|xml|xhtml|rss).*/iu, types, capture: :all_but_first) do
       nil -> {:error, :wrong_headers}
       _   -> :ok
     end


### PR DESCRIPTION
Fix #102 

This PR rewrites the Zooqle scraper to use Zooqle's OpenSearch API, which returns results as RSS feeds.

The rewrite is based on the Nyaa* crawlers, and works in the same way as them.