### PR TITLE
move initial_queue() out of start_link()

### DIFF
--- a/lib/magnetissimo/crawler/eztv.ex
+++ b/lib/magnetissimo/crawler/eztv.ex
@@ -23,14 +23,20 @@ defmodule Magnetissimo.Crawler.EZTV do
   end
 
   def start_link(_) do
-    queue = initial_queue()
-    GenServer.start_link(__MODULE__, queue, name: __MODULE__)
+    GenServer.start_link(__MODULE__, name: __MODULE__)
   end
 
-  def init(queue) do
+  def init(_) do
     Logger.info IO.ANSI.magenta <> "Starting EZTV crawler" <> IO.ANSI.reset
-    schedule_start()
-    {:ok, queue}
+    try do
+      queue = initial_queue()
+      schedule_work()
+      {:ok, queue}
+    rescue
+      exception ->
+         Logger.error inspect exception
+         :ignore
+    end
   end
 
   def schedule_start() do

--- a/lib/magnetissimo/crawler/leetx.ex
+++ b/lib/magnetissimo/crawler/leetx.ex
@@ -28,14 +28,20 @@ defmodule Magnetissimo.Crawler.Leetx do
   end
 
   def start_link(_) do
-    queue = initial_queue()
-    GenServer.start_link(__MODULE__, queue, name: __MODULE__)
+    GenServer.start_link(__MODULE__, name: __MODULE__)
   end
 
-  def init(queue) do
+  def init(_) do
     Logger.info IO.ANSI.magenta <> "Starting Leetx crawler" <> IO.ANSI.reset
-    schedule_work()
-    {:ok, queue}
+    try do
+      queue = initial_queue()
+      schedule_work()
+      {:ok, queue}
+    rescue
+      exception ->
+         Logger.error inspect exception
+         :ignore
+    end
   end
 
   defp schedule_work do
@@ -69,7 +75,7 @@ defmodule Magnetissimo.Crawler.Leetx do
         {:error, message} ->
           Logger.error "[Leetx] "<>  message
           queue
-        _ -> 
+        _ ->
           Logger.error "[Leetx] Something happened when parsing a page looking for torrent URLs…"
     end
   end
@@ -82,7 +88,7 @@ defmodule Magnetissimo.Crawler.Leetx do
             |> Map.put(:outbound_url, url)
             |> Magnetissimo.Torrent.save_torrent
     else
-      {:error, message} -> 
+      {:error, message} ->
         Logger.error "[Leetx] "<> message
     end
     queue

--- a/lib/magnetissimo/crawler/nyaapantsu.ex
+++ b/lib/magnetissimo/crawler/nyaapantsu.ex
@@ -39,14 +39,20 @@ defmodule Magnetissimo.Crawler.NyaaPantsu do
   end
 
   def start_link(_) do
-    queue = initial_queue()
-    GenServer.start_link(__MODULE__, queue, name: __MODULE__)
+    GenServer.start_link(__MODULE__, name: __MODULE__)
   end
 
-  def init(queue) do
+  def init(_) do
     Logger.info IO.ANSI.magenta <> "Starting NyaaPantsu crawler" <> IO.ANSI.reset
-    schedule_work()
-    {:ok, queue}
+    try do
+      queue = initial_queue()
+      schedule_work()
+      {:ok, queue}
+    rescue
+      exception ->
+         Logger.error inspect exception
+         :ignore
+    end
   end
 
   defp schedule_work do

--- a/lib/magnetissimo/crawler/nyaasi.ex
+++ b/lib/magnetissimo/crawler/nyaasi.ex
@@ -39,14 +39,20 @@ defmodule Magnetissimo.Crawler.NyaaSi do
   end
 
   def start_link(_) do
-    queue = initial_queue()
-    GenServer.start_link(__MODULE__, queue, name: __MODULE__)
+    GenServer.start_link(__MODULE__, name: __MODULE__)
   end
 
-  def init(queue) do
+  def init(_) do
     Logger.info IO.ANSI.magenta <> "Starting NyaaSi crawler" <> IO.ANSI.reset
-    schedule_work()
-    {:ok, queue}
+    try do
+      queue = initial_queue()
+      schedule_work()
+      {:ok, queue}
+    rescue
+      exception ->
+         Logger.error inspect exception
+         :ignore
+    end
   end
 
   defp schedule_work do

--- a/lib/magnetissimo/crawler/xbit.ex
+++ b/lib/magnetissimo/crawler/xbit.ex
@@ -26,14 +26,20 @@ defmodule Magnetissimo.Crawler.XBit do
   end
 
   def start_link(_) do
-    queue = initial_queue()
-    GenServer.start_link(__MODULE__, queue, name: __MODULE__)
+    GenServer.start_link(__MODULE__, name: __MODULE__)
   end
 
-  def init(queue) do
+  def init(_) do
     Logger.info IO.ANSI.magenta <> "Starting xBit crawler" <> IO.ANSI.reset
-    schedule_start()
-    {:ok, queue}
+    try do
+      queue = initial_queue()
+      schedule_work()
+      {:ok, queue}
+    rescue
+      exception ->
+         Logger.error inspect exception
+         :ignore
+    end
   end
 
   def schedule_start() do

--- a/lib/magnetissimo/crawler/zooqle.ex
+++ b/lib/magnetissimo/crawler/zooqle.ex
@@ -28,14 +28,20 @@ defmodule Magnetissimo.Crawler.Zooqle do
   end
 
   def start_link(_) do
-    queue = initial_queue()
-    GenServer.start_link(__MODULE__, queue, name: __MODULE__)
+    GenServer.start_link(__MODULE__, name: __MODULE__)
   end
 
   def init(queue) do
     Logger.info IO.ANSI.magenta <> "Starting Zooqle crawler" <> IO.ANSI.reset
-    schedule_work()
-    {:ok, queue}
+    try do
+      queue = initial_queue()
+      schedule_work()
+      {:ok, queue}
+    rescue
+      exception ->
+         Logger.error inspect exception
+         :ignore
+    end
   end
 
   defp schedule_work do


### PR DESCRIPTION
fixes #110

This PR moves the call to `initial_queue` out of `start_link` and into `init`, and traps any errors which occur, returning `:ignore` instead.

This will prevent the supervisor from terminating if either `initial_queue` or `schedule_work` fails, and prevent the crawler from being immediately restarted by the supervisor in these cases.