### PR TITLE
Fix `mix test`

### DIFF
--- a/lib/magnetissimo/application.ex
+++ b/lib/magnetissimo/application.ex
@@ -14,7 +14,8 @@ defmodule Magnetissimo.Application do
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: Magnetissimo.Supervisor]
 
-    :ok = :error_logger.add_report_handler(Sentry.Logger)
+    if Code.ensure_loaded?(Sentry.Logger), do:
+        :ok = :error_logger.add_report_handler(Sentry.Logger)
     Supervisor.start_link(children, opts)
   end
 

--- a/lib/magnetissimo_web/router.ex
+++ b/lib/magnetissimo_web/router.ex
@@ -2,7 +2,7 @@ defmodule MagnetissimoWeb.Router do
   use MagnetissimoWeb, :router
 
   use Plug.ErrorHandler
-  use Sentry.Plug
+  if Code.ensure_loaded?(Sentry.Plug), do: quote do: use Sentry.Plug
 
   pipeline :browser do
     plug :accepts, ["html"]

--- a/mix.exs
+++ b/mix.exs
@@ -64,8 +64,7 @@ defmodule Magnetissimo.Mixfile do
   defp aliases do
     [
       "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
-      "ecto.reset": ["ecto.drop", "ecto.setup"],
-      "test": ["ecto.create --quiet", "ecto.migrate", "test"]
+      "ecto.reset": ["ecto.drop", "ecto.setup"]
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,6 @@
-%{"bento": {:hex, :bento, "0.9.2", "7c12c68a34c5e63ff9e71506dcedcd2f983055ac1c40edcd86750ead09e2a174", [:mix], [{:poison, "~> 2.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
+%{
+  "bento": {:hex, :bento, "0.9.2", "7c12c68a34c5e63ff9e71506dcedcd2f983055ac1c40edcd86750ead09e2a174", [:mix], [{:poison, "~> 2.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
+  "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
   "certifi": {:hex, :certifi, "2.0.0", "a0c0e475107135f76b8c1d5bc7efb33cd3815cb3cf3dea7aefdd174dabead064", [:rebar3], [], "hexpm"},
   "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm"},
   "cowboy": {:hex, :cowboy, "1.1.2", "61ac29ea970389a88eca5a65601460162d370a70018afe6f949a29dca91f3bb0", [:rebar3], [{:cowlib, "~> 1.0.2", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.3.2", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
@@ -36,4 +38,5 @@
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], [], "hexpm"},
   "tesla": {:hex, :tesla, "0.10.0", "e588c7e7f1c0866c81eeed5c38f02a4a94d6309eede336c1e6ca08b0a95abd3f", [:mix], [{:exjsx, ">= 0.1.0", [hex: :exjsx, repo: "hexpm", optional: true]}, {:fuse, "~> 2.4", [hex: :fuse, repo: "hexpm", optional: true]}, {:hackney, "~> 1.6", [hex: :hackney, repo: "hexpm", optional: true]}, {:ibrowse, "~> 4.2", [hex: :ibrowse, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}, {:poison, ">= 1.0.0", [hex: :poison, repo: "hexpm", optional: true]}], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], [], "hexpm"},
-  "uuid": {:hex, :uuid, "1.1.8", "e22fc04499de0de3ed1116b770c7737779f226ceefa0badb3592e64d5cfb4eb9", [], [], "hexpm"}}
+  "uuid": {:hex, :uuid, "1.1.8", "e22fc04499de0de3ed1116b770c7737779f226ceefa0badb3592e64d5cfb4eb9", [], [], "hexpm"},
+}

--- a/test/magnetissimo_web/controllers/page_controller_test.exs
+++ b/test/magnetissimo_web/controllers/page_controller_test.exs
@@ -3,6 +3,6 @@ defmodule MagnetissimoWeb.PageControllerTest do
 
   test "GET /", %{conn: conn} do
     conn = get conn, "/"
-    assert html_response(conn, 200) =~ "Welcome to Phoenix!"
+    assert html_response(conn, 200) =~ "Magnetissimo"
   end
 end


### PR DESCRIPTION
add guards around calls to Sentry, since it's only
loaded in :dev

fix PageControllerTest so it checks for something sane

remove `test` alias, since we don't actually want to run create
or migrate before testing