### PR TITLE
Add Docker Compose file

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,24 @@ We want to explain how to run Magnetissimo on:
 - Windows
 - Linux
 - Mac
+- Docker Compose
+  ```
+  # Generate a secret_key
+  openssl rand -hex 32
 
-Right now you can run Magnetissimo via it's Dockerfile or through your CLI:
+  # Enter that key as SECRET_KEY_BASE in the docker-compse.yml file
+  SECRET_KEY_BASE=YourKeyGoesHere
 
-```
-asdf install
-mix deps.get
-iex -S mix phx.server
-```
+  # Start the application
+  docker compose up -d
+  ```
+- CLI
+
+  ```
+  asdf install
+  mix deps.get
+  iex -S mix phx.server
+  ```
 
 Then visit: http://localhost:4000
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+version: '3'
+services:
+  postgres:
+    container_name: postgres
+    image: postgres:15.2-alpine
+    restart: unless-stopped
+    environment:
+      - POSTGRES_USER=user1
+      - POSTGRES_PASSWORD=pass1
+      - POSTGRES_DB=magnetissimo
+    networks:
+      - magnetissimo
+    volumes:
+      - 'pgdata:/var/lib/postgresql/data'
+  magnetissimo:
+    container_name: magnetissimo
+    build: https://github.com/sergiotapia/magnetissimo.git
+    restart: unless-stopped
+    environment:
+      - DATABASE_URL=ecto://user1:pass1@postgres:5432/magnetissimo
+      - SECRET_KEY_BASE=YourKeyGoesHere
+    networks:
+      - magnetissimo
+    ports:
+      - '4000:4000/tcp'
+    depends_on:
+      - postgres
+
+networks:
+  magnetissimo:
+
+volumes:
+  pgdata:
+    driver: local


### PR DESCRIPTION
This is a basic `docker-compose.yml` file. A couple things:

1. Because the images aren't published to DockerHub or GHCR, I'm having to use the `build` element to build the image each time (this takes about a minute on a modern-ish laptop). Ideally, you would pre-build and publish the images for users to consume.
2. What is `SECRET_KEY_BASE`? The app wouldn't start unless I set an environment variable for `SECRET_KEY_BASE`.
```
ERROR! Config provider Config.Reader failed with:
** (RuntimeError) environment variable SECRET_KEY_BASE is missing.
You can generate one by calling: mix phx.gen.secret

    /app/releases/2.0.0/runtime.exs:46: (file)
    (elixir 1.14.4) src/elixir.erl:309: anonymous fn/4 in :elixir.eval_external_handler/1
    (stdlib 4.1.1) erl_eval.erl:748: :erl_eval.do_apply/7
    (stdlib 4.1.1) erl_eval.erl:492: :erl_eval.expr/6
    (stdlib 4.1.1) erl_eval.erl:136: :erl_eval.exprs/6
    (elixir 1.14.4) src/elixir.erl:294: :elixir.eval_forms/4
    (elixir 1.14.4) lib/module/parallel_checker.ex:110: Module.ParallelChecker.verify/1
    (elixir 1.14.4) lib/code.ex:425: Code.validated_eval_string/3
```
3. When I had the `SECRET_KEY_BASE` set to `asdf`, it complained that it was too short. I had to run `openssl rand -hex 32` to generate a key. Does this need to stay static for the life of the database? What kind of characters should make up this key? Is 64 characters enough, or should it be longer?
```
23:56:46.653 request_id=F1Wj3UYqF21tkncAAABB [info] GET /
23:56:46.661 request_id=F1Wj3UYqF21tkncAAABB [info] Sent 500 in 8ms
23:56:46.661 [error] #PID<0.2601.0> running MagnetissimoWeb.Endpoint (connection #PID<0.2600.0>, stream id 1) terminated
Server: localhost:4000 (http)
Request: GET /
** (exit) an exception was raised:
    ** (ArgumentError) cookie store expects conn.secret_key_base to be at least 64 bytes
        (plug 1.14.2) lib/plug/session/cookie.ex:185: Plug.Session.COOKIE.validate_secret_key_base/1
        (plug 1.14.2) lib/plug/session/cookie.ex:177: Plug.Session.COOKIE.derive/3
        (plug 1.14.2) lib/plug/session/cookie.ex:96: Plug.Session.COOKIE.put/4
        (plug 1.14.2) lib/plug/session.ex:96: anonymous fn/3 in Plug.Session.before_send/2
        (elixir 1.14.4) lib/enum.ex:2468: Enum."-reduce/3-lists^foldl/2-0-"/3
        (plug 1.14.2) lib/plug/conn.ex:1836: Plug.Conn.run_before_send/2
        (plug 1.14.2) lib/plug/conn.ex:443: Plug.Conn.send_resp/1
        (phoenix 1.7.2) lib/phoenix/router.ex:430: Phoenix.Router.__call__/5
```
4. Maybe it's just me, but the app loaded on http://localhost:4000, but kept saying `We can't find the internet`...