### PR TITLE
GHCR Caches

### DIFF
--- a/.github/workflows/ghcr-image.yml
+++ b/.github/workflows/ghcr-image.yml
@@ -34,7 +34,8 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
+      - name: Setups buildx
+        uses: docker/setup-buildx-action@v1
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
@@ -46,5 +47,7 @@ jobs:
         with:
           context: .
           push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Probs should've included with the initial PR, but added another that properly uses the Github cache for docker builds to decrease build time from ~3m -> 30s after first run