### PR TITLE
Fix ssl_verify_fun problems

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -61,7 +61,8 @@ defmodule Magnetissimo.MixProject do
       {:size, "~> 0.1.1"},
       {:earmark, "~> 1.4"},
       {:html_sanitize_ex, "~> 1.4"},
-      {:oban, "~> 2.14"}
+      {:oban, "~> 2.14"},
+      {:ssl_verify_fun, "~> 1.1.7"},
     ]
   end
 


### PR DESCRIPTION
Fixing errors during compilation caused by https://github.com/deadtrickster/ssl_verify_fun.erl/pull/27 
patched only in 1.1.7.

```shell
could not compile dependency :ssl_verify_fun, "mix compile" failed. Errors may have been logged above. You can recompile this dependency with "mix deps.compile ssl_verify_fun --force", update it with "mix deps.update ssl_verify_fun" or clean it with "mix deps.clean ssl_verify_fun"
``` 